### PR TITLE
added biology configuration files to the experiment folder

### DIFF
--- a/TP5a0.06/expt_01.1/atmo_synoptic.sh
+++ b/TP5a0.06/expt_01.1/atmo_synoptic.sh
@@ -1,1 +1,0 @@
-/nird/home/aal069/NERSC-HYCOM-CICE/bin/atmo_synoptic.sh

--- a/TP5a0.06/expt_01.1/common_functions.sh
+++ b/TP5a0.06/expt_01.1/common_functions.sh
@@ -1,1 +1,0 @@
-/nird/home/aal069/NERSC-HYCOM-CICE/bin/common_functions.sh

--- a/TP5a0.06/expt_01.1/compile_model.sh
+++ b/TP5a0.06/expt_01.1/compile_model.sh
@@ -1,1 +1,0 @@
-/nird/home/aal069/NERSC-HYCOM-CICE/bin/compile_model.sh

--- a/TP5a0.06/expt_01.1/create_ref_case.sh
+++ b/TP5a0.06/expt_01.1/create_ref_case.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-myclim="woa2013" # Climatology to use
+myclim="woa2018" # Climatology to use
 #myclim="phc" # Climatology to use
 
 Icore=23
@@ -75,7 +75,7 @@ if [ $NTRACR -ne 0 ] ; then
   # Create CO2 z-relaxation files from GLODAPV2
   cd $EDIR
   echo "co2 relax climatology"
-  z_glodap_co2.sh $KSIGMA > $EDIR/log/ref_bio_relax.out 2>&1
+  z_glodap_co2.sh $KSIGMA > $EDIR/log/ref_co2_relax.out 2>&1
   res=$?
   [ $res -eq 0 ] && echo "Success"
   [ $res -ne 0 ] && echo "Failure... Log in $EDIR/log/ref_co2_relax.out"

--- a/TP5a0.06/expt_01.1/expt_preprocess.sh
+++ b/TP5a0.06/expt_01.1/expt_preprocess.sh
@@ -1,1 +1,0 @@
-/nird/home/aal069/NERSC-HYCOM-CICE/bin/expt_preprocess.sh

--- a/TP5a0.06/expt_01.1/fabm.yaml
+++ b/TP5a0.06/expt_01.1/fabm.yaml
@@ -1,0 +1,119 @@
+instances:
+
+  light:
+    model: gotm/light
+
+  CO2:
+    model: pml/carbonate
+    parameters:
+      alk_param: false      # compute alkalinity as linear function of salinity, default = true
+      #alk_offset: 520.1    # offset for alkalinity as linear function of salinity (mEq m-3), default = 520.1
+      #alk_slope: 51.24     # scale factor for alkalinity as linear function of salinity (mEq m-3), default = 51.24
+      pCO2a: 0. #367.0         # mole fraction of atmospheric CO2 (ppm), default = 0.0
+
+    initialization:
+      dic: 2200.0          # total dissolved inorganic carbon (mmol m-3)
+      alk: 2300.0
+
+  ECO:    # When coupled to HYCOM, do not change this to another name
+    model: nersc_ecosmo_operational
+    parameters:
+      muPl       : 1.75     # max growth rate for Pl          (1/d),                        default=1.30
+      muPs       : 1.45     # max growth rate for Ps          (1/d),                        default=1.10
+      aa         : 0.012    # photosynthesis ef-cy            (m**2/W),                     default=0.03
+      EXw        : 0.04     # light extinction                (1/m),                        default=0.05
+      EXphy      : 0.041    # phyto self-shading              (m**2/mmolN),                 default=0.03
+      rNH4       : 0.20     # NH4 half saturation             (mmolN/m**3),                 default=0.20
+      rNO3       : 0.50     # NO3 half saturation             (mmolN/m**3),                 default=0.50
+      psi        : 3.00     # NH4 inhibition                  (m**3/mmolN),                 default=3.00
+      mPl        : 0.04     # Pl mortality rate               (1/d),                        default=0.04
+      mPs        : 0.08     # Ps mortality rate               (1/d),                        default=0.08
+      GrZlP      : 1.20     # Grazing rate Zl on Phyto        (1/d),                        default=0.80
+      GrZsP      : 1.50     # Grazing rate Zs on Phyto        (1/d),                        default=1.00
+      GrZlZ      : 0.75     # Grazing rate Zl on Zs           (1/d),                        default=0.50
+      Rg         : 0.50     # Zs, Zl half saturation          (mmolN/m**3),                 default=0.50
+      mZl        : 0.20     # Zl mortality rate               (1/d),                        default=0.10
+      mZs        : 0.40     # Zs mortality rate               (1/d),                        default=0.20
+      excZl      : 0.06     # Zl excretion rate               (1/d),                        default=0.06
+      excZs      : 0.08     # Zs excretion rate               (1/d),                        default=0.08
+      gammaZlp   : 0.75     # Zl assim. eff. on plankton      (-),                          default=0.75
+      gammaZsp   : 0.75     # Zs assim. eff. on plankton      (-),                          default=0.75
+      gammaZd    : 0.75     # Zl & Zs assim. eff. on det      (-),                          default=0.75
+      reminD     : 0.003    # Detritus remineralization rate  (1/d),                        default=0.003
+      sinkDet    : 5.00     # Detritus sinking rate           (m/d),                        default=5.00
+      Wa         : 1.00     # Don't know what this is yet     (m/d),                        default=1.00
+      rPO4       : 0.05     # PO4 half saturation             (mmolP/m**3),                 default=0.05
+      rSi        : 0.50     # SiO2 half saturation            (mmolSi/m**3),                default=0.50
+      regenSi    : 0.015    # Si regeneration rate            (1/d),                        default=0.015
+      muBG       : 1.00     # max growth rate for BG          (1/d),                        default=1.00
+      TctrlBG    : 1.00     # BG T control beta               (1/degC),                     default=1.00
+      TrefBG     : 0.00     # BG reference temperature        (degC),                       default=0.00
+      GrBG       : 0.30     # BG max grazing rate             (1/d),                        default=0.30
+      mBG        : 0.08     # BG mortality rate               (1/d),                        default=0.08
+      upliftBG   : 0.10     # BG uplifting rate               (m/d),                        default=0.10
+      crBotStr   : 0.021    # c2        ritic. bot. stress for resusp. (N/m**2),            default=0.007
+      resuspRt   : 25.00    # resuspension rate               (1/d),                        default=25.00
+      sedimRt    : 5.0      # sedimentation rate              (m/d),                        default=3.50
+      burialRt   : 0.00001  # burial rate                     (1/d),                        default=0.00001
+      reminSED   : 0.001    # sediment remineralization rate  (1/d),                        default=0.001
+      TctrlDenit : 0.15     # temp. control denitrification   (1/degC),                     default=0.15
+      RelSEDp1   : 0.15     # P sedim. rel. p1                (-),                          default=0.15
+      RelSEDp2   : 0.10     # P sedim. rel. p2                (-),                          default=0.10
+      reminSEDsi : 0.0002   # sed. remineralization rate Si   (1/d),                        default=0.0002
+      sinkOPAL   : 5.00     # OPAL sinking rate               (m/d),                        default=5.00
+      sinkBG     : -1.00    # BG sinking rate                 (m/d),                        default=-1.00
+      sinkDia    : 0.00     # Diatom sinking rate             (m/d),                        default=0.00
+      prefZsPs   : 0.68     # Grazing preference Zs on Ps     (-),                          default=0.70
+      prefZsPl   : 0.24     # Grazing preference Zs on Pl     (-),                          default=0.25
+      prefZsD    : 0.08     # Grazing preference Zs on Det.   (-),                          default=0.00
+      prefZsBG   : 0.0      # Grazing preference Zs on BG     (-),                          default=0.30
+      prefZlPs   : 0.08     # Grazing preference Zl on Ps     (-),                          default=0.10
+      prefZlPl   : 0.72     # Grazing preference Zl on Pl     (-),                          default=0.85
+      prefZlZs   : 0.12     # Grazing preference Zl on Zs     (-),                          default=0.15
+      prefZlD    : 0.08     # Grazing preference Zl on Det.   (-),                          default=0.00
+      prefZlBG   : 0.0      # Grazing preference Zl on BG     (-),                          default=0.30
+      zpr        : 0.00     # zpr_long_name_needed            (?),                          default=0.001
+      frr        : 0.4      # fraction of dissolved from det. (-),                          default=0.4
+      MINchl2nPs : 0.5      # minimum Chl to N ratio Ps       (mgChl/mmolN),                default=0.5
+      MAXchl2nPs : 3.83     # maximum Chl to N ratio Ps       (mgChl/mmolN),                default=3.83
+      MINchl2nPl : 0.5      # minimum Chl to N ratio Pl       (mgChl/mmolN),                default=0.5
+      MAXchl2nPl : 2.94     # maximum Chl to N ratio Pl       (mgChl/mmolN),                default=2.94
+      MINchl2nBG : 0.5      # minimum Chl to N ratio BG       (mgChl/mmolN),                default=0.5
+      MAXchl2nBG : 2.94     # maximum Chl to N ratio BG       (mgChl/mmolN),                default=2.94
+      alfaPs     : 0.0393   # initial slope P-I curve Ps      (mmolN m2/(mgChl day W)**-1), default=0.0393
+      alfaPl     : 0.0531   # initial slope P-I curve Pl      (mmolN m2/(mgChl day W)**-1), default=0.0531
+      alfaBG     : 0.0393   # initial slope P-I curve BG      (mmolN m2/(mgChl day W)**-1), default=0.0393
+      surface_deposition_no3      : 0. #0.35  # surface deposition no3, default = 0.35
+      surface_deposition_nh4      : 0. #0.35 # surface deposition nh4, default = 0.32
+      surface_deposition_pho      : 0. #0.045  # surface deposition pho, default = 0.045
+      surface_deposition_sil      : 0. #0.5  # surface_deposition sil, default = 0.50
+      bg_growth_minimum_daily_rad : 120.0 #10000.0 # bg growth minimum daily rad, default = 120.0
+      nfixation_minimum_daily_par : 35.0 # 10000.0  # nfixation minimum daily par, default = 35.0
+      use_chl: true 
+      use_cyanos: false 
+      couple_co2: true
+
+    coupling:
+      dic_target: CO2_dic
+      alk_target: CO2_alk
+
+    initialization:
+      no3        : 400.0     # nitrate (mgC/m**3)
+      nh4        : 8.0     # ammonium (mgC/m**3)
+      oxy        : 10.0    # ?? check the unit ?? oxygen (mmolO2/m**3)
+      pho        : 382.0     # phosphate (mgC/m**3)
+      det        : 0.1     # detritus (mgC/m**3)
+      dom        : 3.0     # labile dissolved om (mgC/m**3)
+      sil        : 400.0     # silicate (mgC/m**3)
+      opa        : 0.1     # opal (mgC/m**3)
+      dia        : 0.1    # large phytoplankton (mgC/m**3)
+      fla        : 0.1    # small phytoplankton (mgC n/m**3)
+      mesozoo    : 0.01    # mesozooplankton (mgC/m**3)
+      microzoo   : 0.01    # microzooplankton (mgC/m**3)
+      #bg         : 1e-7    # cyanobacteria (mgC/m**3)
+      diachl     : 0.005    # ?? check units ?? large phytoplankton chl-a (mgChl/m**3)
+      flachl     : 0.005    # ?? check units ?? small phytoplankton chl-a (mgChl/m**3)
+      #bgchl      : 1e-8    # ?? check units ?? cyanobacteria chl-a (mgChl/m**3)
+      sed1       : 113.6 # mgC/m2 (20mgN in C units)
+      sed2       : 56.65 # mgC/m2 (20mgSi in C units)
+      sed3       : 82.2  # mgC/m2 (2mgP in C units)

--- a/TP5a0.06/expt_01.1/hycom_fabm.nml
+++ b/TP5a0.06/expt_01.1/hycom_fabm.nml
@@ -1,0 +1,7 @@
+&hycom_fabm
+  do_vertical_movement = .true.
+  do_interior_sources = .true.
+  do_bottom_sources = .true.
+  do_surface_sources = .true.
+  nested_variables = 'ECO_no3','ECO_pho','ECO_sil'
+/


### PR DESCRIPTION
added biology configuration files to the experiment folder

I assumed expt01.1 was the default one. Why are there some links in that folder?
The blkdat file by default will not run biology.
To activate biology one should set ntrac=1 or -1
Tracer relaxation at the boundary is set to 0 at the moment because TP5 is intended to be used with nesting at the boundary. The configuration is set in hycom_fabm.nml file to activate nutrient nesting if nesting by hycom is activated in blkdat