### PR TITLE
fixed a small bug that causes double allocation of an allocatable arr…

### DIFF
--- a/hycom/MSCPROGS/src/Hyc2proj/p_hyc2stations.F90
+++ b/hycom/MSCPROGS/src/Hyc2proj/p_hyc2stations.F90
@@ -111,6 +111,8 @@ program p_hyc2stations
 
    ! This file will contain a list of data files produced by this routine
    open(96,file='hyc2stations.filelist',action='write',status='replace')
+   ! Alfati.: call zaioempty to deallocate
+   call zaioempty ! deallocated za - fields - ready for next file
 
    ! Were ready...
    print *


### PR DESCRIPTION

calling the function "zaiost()" will involve allocation of an array,  and hence it should be deallocated before the next call. If left not fixed, the bug will crash 'hyc2station' with the below error:


forrtl: severe (151): allocatable array is already allocated