### PR TITLE
u-vel. and v-vel in the instantaneous archive files represent barocli…

### DIFF
--- a/hycom/MSCPROGS/src/Nersclib/mod_hycomfile_io.F90
+++ b/hycom/MSCPROGS/src/Nersclib/mod_hycomfile_io.F90
@@ -791,8 +791,8 @@ contains
       call HFReadField(df,ub,idm,jdm,'u_btrop ',0,1)
       call HFReadField(df,vb,idm,jdm,'v_btrop ',0,1)
    elseif(trim(df%ftype)=="archm") then
-      call HFReadField(df,ut,idm,jdm,'u-vel.  ',vlevel,1)
-      call HFReadField(df,vt,idm,jdm,'v-vel.  ',vlevel,1)
+      call HFReadField(df,ut,idm,jdm,'utotl  ',vlevel,1)
+      call HFReadField(df,vt,idm,jdm,'vtotl  ',vlevel,1)
    elseif (trim(df%ftype)=="archv_wav") then
       call HFReadField(df,ut,idm,jdm,'u-vel.  ',vlevel,1)
       call HFReadField(df,vt,idm,jdm,'v-vel.  ',vlevel,1)

--- a/hycom/MSCPROGS/src/Nersclib/mod_hycomfile_io.F90
+++ b/hycom/MSCPROGS/src/Nersclib/mod_hycomfile_io.F90
@@ -785,12 +785,14 @@ contains
       call HFReadField(df,ut,idm,jdm,'utot    ',vlevel,1)
       call HFReadField(df,vt,idm,jdm,'vtot    ',vlevel,1)
    elseif(trim(df%ftype)=="archv"&
-           .or.trim(df%ftype)=="archm"&
            .or.trim(df%ftype)=="archs") then
       call HFReadField(df,ut,idm,jdm,'u-vel.  ',vlevel,1)
       call HFReadField(df,vt,idm,jdm,'v-vel.  ',vlevel,1)
       call HFReadField(df,ub,idm,jdm,'u_btrop ',0,1)
       call HFReadField(df,vb,idm,jdm,'v_btrop ',0,1)
+   elseif(trim(df%ftype)=="archm") then
+      call HFReadField(df,ut,idm,jdm,'u-vel.  ',vlevel,1)
+      call HFReadField(df,vt,idm,jdm,'v-vel.  ',vlevel,1)
    elseif (trim(df%ftype)=="archv_wav") then
       call HFReadField(df,ut,idm,jdm,'u-vel.  ',vlevel,1)
       call HFReadField(df,vt,idm,jdm,'v-vel.  ',vlevel,1)

--- a/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_mean.F
+++ b/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_mean.F
@@ -609,13 +609,13 @@ c
       call zaiowr(u_m(1-nbdy,1-nbdy,k),iu,.true.,
      &            xmin,xmax, nopa, .false.)
       if     (mnproc.eq.1) then
-      write (nop,117) 'u-vel.  ',nmean,time_ave,k,coord,xmin,xmax
+      write (nop,117) 'utotl   ',nmean,time_ave,k,coord,xmin,xmax
       call flush(nop)
       endif !1st tile
       call zaiowr(v_m(1-nbdy,1-nbdy,k),iv,.true.,
      &            xmin,xmax, nopa, .false.)
       if     (mnproc.eq.1) then
-      write (nop,117) 'v-vel.  ',nmean,time_ave,k,coord,xmin,xmax
+      write (nop,117) 'vtotl   ',nmean,time_ave,k,coord,xmin,xmax
       call flush(nop)
       endif !1st tile
       call zaiowr(ke_m(1-nbdy,1-nbdy,k),ip,.true.,


### PR DESCRIPTION
This is according to Alan and also explained here, see from line 530 in https://github.com/nansencenter/NERSC-HYCOM-CICE/blob/develop/hycom/hycom_ALL/hycom_2.2.72_ALL/archive/src_2.2.35/archv2data3z.f

Now hyc2proj is corrected so that it will consider (u-vel. , v-vel) as the total velocity if filetype is mean "archm" file   