### PR TITLE
Adjust dragcoefficient ice/ocean

### DIFF
--- a/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_momtum.F
+++ b/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_momtum.F
@@ -54,9 +54,10 @@ c
       logical, parameter :: lpipe_momtum=.false.      !usually .false.
 
 #if not defined(icestress)
-c Currently drag cofficient in cice is half the magnitude
-      real,    parameter :: dragw_rho=0.01072d0*1026.0d0  !ice-ocean drag from CICE
-c     CICE USES                       0.00536d0*1026.0d0
+c Reduced dragw_rho to half in order to align with CICE
+       real,    parameter :: dragw_rho=0.01072d0*1026.0d0  !ice-ocean drag from CICE
+c      real,    parameter :: dragw_rho=0.01072d0*1026.0d0  !ice-ocean drag original
+
 #endif
       real,    parameter ::     pairc=1013.0d0*100.0d0    !air pressure (Pa)
       real,    parameter ::      rgas=287.1d0           !gas constant (j/kg/k)
@@ -507,6 +508,8 @@ c
                 surty(i,j) = 0.0
               elseif (iceflg.eq.2 .and. si_c(i,j).gt.0.0) then
 c ---           allow for ice-ocean stress
+! DONT COMPILE WITH CPP FLAG icestress now
+! AN ISSUE MUST BE RESOLVED FIRST
 #ifdef icestress
                 surtx(i,j) = (1.0-si_c(i,j))*surtx(i,j) +
      &                            si_tx(i,j)

--- a/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_momtum.F
+++ b/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_momtum.F
@@ -53,12 +53,10 @@ c --- -----------------------------------------
 c
       logical, parameter :: lpipe_momtum=.false.      !usually .false.
 
-#if not defined(icestress)
 c Reduced dragw_rho to half in order to align with CICE
-       real,    parameter :: dragw_rho=0.01072d0*1026.0d0  !ice-ocean drag from CICE
-c      real,    parameter :: dragw_rho=0.01072d0*1026.0d0  !ice-ocean drag original
+      real,    parameter :: dragw_rho=0.00536d0*1026.0d0  !ice-ocean drag from CICE
+c     real,    parameter :: dragw_rho=0.01072d0*1026.0d0  !ice-ocean drag original
 
-#endif
       real,    parameter ::     pairc=1013.0d0*100.0d0    !air pressure (Pa)
       real,    parameter ::      rgas=287.1d0           !gas constant (j/kg/k)
       real,    parameter ::     tzero=273.16d0          !celsius to kelvin offset

--- a/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_momtum.F
+++ b/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_momtum.F
@@ -53,8 +53,10 @@ c --- -----------------------------------------
 c
       logical, parameter :: lpipe_momtum=.false.      !usually .false.
 
-
+#if not defined(icestress)
+c Currently drag cofficient in cice is half the magnitude
       real,    parameter :: dragw_rho=0.01072d0*1026.0d0  !ice-ocean drag from CICE
+#endif
       real,    parameter ::     pairc=1013.0d0*100.0d0    !air pressure (Pa)
       real,    parameter ::      rgas=287.1d0           !gas constant (j/kg/k)
       real,    parameter ::     tzero=273.16d0          !celsius to kelvin offset
@@ -504,6 +506,13 @@ c
                 surty(i,j) = 0.0
               elseif (iceflg.eq.2 .and. si_c(i,j).gt.0.0) then
 c ---           allow for ice-ocean stress
+#ifdef icestress
+                surtx(i,j) = (1.0-si_c(i,j))*surtx(i,j) +
+     &                            si_tx(i,j)
+                surty(i,j) = (1.0-si_c(i,j))*surty(i,j) +
+     &                            si_ty(i,j)
+
+#else
                 uimo = si_u(i,j) - usur
                 vimo = si_v(i,j) - vsur
                 simo = sqrt( uimo**2 + vimo**2 )
@@ -511,6 +520,7 @@ c ---           allow for ice-ocean stress
      &                            si_c(i,j) *dragw_rho*simo*uimo
                 surty(i,j) = (1.0-si_c(i,j))*surty(i,j) +
      &                            si_c(i,j) *dragw_rho*simo*vimo
+#endif
               endif !ice-ocean stress
             endif !ip
           enddo !i

--- a/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_momtum.F
+++ b/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_momtum.F
@@ -56,6 +56,7 @@ c
 #if not defined(icestress)
 c Currently drag cofficient in cice is half the magnitude
       real,    parameter :: dragw_rho=0.01072d0*1026.0d0  !ice-ocean drag from CICE
+c     CICE USES                       0.00536d0*1026.0d0
 #endif
       real,    parameter ::     pairc=1013.0d0*100.0d0    !air pressure (Pa)
       real,    parameter ::      rgas=287.1d0           !gas constant (j/kg/k)


### PR DESCRIPTION
The drag coefficient between ocean and sea ice differs between HYCOM and CICE by a factor of two
drivers/cice/ice_constants.F90:         dragio    = 0.00536_dbl_kind ,&! ice-ocn drag coefficient
Line 57 mod_momtum.F                 dragw_rho=0.01072d0*1026.0d0
In the end of mod_momtum there is a comment that suggest that the ocean value is correct if  
c> Oct. 2042 - dragw_rho appropriate for thkcdw=3.0, 2x default. This is the value used. If this should be followed then the drag coefficients in CICE and HYCOM should be modified to this.
For now the CICE value has been used.
This results in slighty more ice.

In additon CPP flag icestress is added to mod_momtum in order to allow for coupling of stress instead of velocities. THIS SHOULD NOT BE USED FOR NOW as it introduce an instability due to excessive ridging and as a consequence of this a crash after 50 days of simulation.
A few differences has been found in the coupling  This will be tested within the next days.