### PR TITLE
allow for restart from ice_initial.nc, fields aice and hi

### DIFF
--- a/bin/cice_limits.py
+++ b/bin/cice_limits.py
@@ -47,7 +47,8 @@ def main(start_time,end_time,init,nmpi,fnml) :
       nml["setup_nml"]["runtype"]="initial"
       nml["setup_nml"]["restart"]=False
       nml["setup_nml"]["use_restart_time"]=False
-      nml["setup_nml"]["ice_ic"]="default"
+     # nml["setup_nml"]["ice_ic"]="default"
+      nml["setup_nml"]["ice_ic"]="read"
    else :
       nml["setup_nml"]["runtype"]="continue"
       nml["setup_nml"]["restart"]=True

--- a/cice/Release-5.1/source/ice_init.F90
+++ b/cice/Release-5.1/source/ice_init.F90
@@ -1819,7 +1819,7 @@
       do j = jlo, jhi
         do i = ilo, ihi
            if (tmask(i,j)) then
-               if (sst (i,j) <= Tf(i,j)+p2) then
+               if (sst (i,j) <= Tf(i,j)+p2 .and. abar2d(i,j) > 0.15) then
                   icells = icells + 1
                   indxi(icells) = i
                   indxj(icells) = j


### PR DESCRIPTION
Expand the options for cold start from a file named ice_initial with fields aice and hi.
in namelist ice_in ice_ic must be set to 'read' and ocn_data_dir should be the path of the location of the file. If in SCRATCH './' is sufficient. All ice is put in the same category. 