### PR TITLE
Tuning CICE for reducing ice drift and increasing a bit of ice thickn…

### DIFF
--- a/cice/Release-5.1/drivers/esmf/ice_constants.F90
+++ b/cice/Release-5.1/drivers/esmf/ice_constants.F90
@@ -61,7 +61,7 @@
          spval     = 1.0e30_real_kind   ! special value for netCDF output
 
       real (kind=dbl_kind), parameter, public :: &
-         iceruf   = 0.0005_dbl_kind   ,&! ice surface roughness (m)
+         iceruf   = 0.00015_dbl_kind   ,&! ice surface roughness (m)
 
          ! (Ebert, Schramm and Curry JGR 100 15965-15975 Aug 1995)
          kappav = 1.4_dbl_kind ,&! vis extnctn coef in ice, wvlngth<700nm (1/m)

--- a/cice/Release-5.1/source/ice_dyn_shared.F90
+++ b/cice/Release-5.1/source/ice_dyn_shared.F90
@@ -40,8 +40,8 @@
                          ! coefficient for calculating the parameter E
          !cosw = c1   , & ! cos(ocean turning angle)  ! turning angle = 0
          !sinw = c0   , & ! sin(ocean turning angle)  ! turning angle = 0
-         cosw = 0.9848   , & ! cos(ocean turning angle)  ! turning angle 10 deg
-         sinw = 0.1736   , & ! sin(ocean turning angle)  ! turning angle 10 deg
+         cosw = 0.9848_dbl_kind, & ! cos(ocean turning angle)  ! turning angle 10 deg
+         sinw = 0.1736_dbl_kind, & ! sin(ocean turning angle)  ! turning angle 10 deg
 
          a_min = p001, & ! minimum ice area
          m_min = p01     ! minimum ice mass (kg/m^2)

--- a/cice/Release-5.1/source/ice_dyn_shared.F90
+++ b/cice/Release-5.1/source/ice_dyn_shared.F90
@@ -38,8 +38,11 @@
       real (kind=dbl_kind), parameter, public :: &
          eyc = 0.36_dbl_kind, &
                          ! coefficient for calculating the parameter E
-         cosw = c1   , & ! cos(ocean turning angle)  ! turning angle = 0
-         sinw = c0   , & ! sin(ocean turning angle)  ! turning angle = 0
+         !cosw = c1   , & ! cos(ocean turning angle)  ! turning angle = 0
+         !sinw = c0   , & ! sin(ocean turning angle)  ! turning angle = 0
+         cosw = 0.9848   , & ! cos(ocean turning angle)  ! turning angle 10 deg
+         sinw = 0.1736   , & ! sin(ocean turning angle)  ! turning angle 10 deg
+
          a_min = p001, & ! minimum ice area
          m_min = p01     ! minimum ice mass (kg/m^2)
 

--- a/cice/Release-5.1/source/ice_mechred.F90
+++ b/cice/Release-5.1/source/ice_mechred.F90
@@ -77,7 +77,8 @@
          Hstar  = c25        , & ! determines mean thickness of ridged ice (m) 
                                  ! (krdg_redist = 0) 
                                  ! Flato & Hibler (1995) have Hstar = 100 
-         Pstar = 2.75e4_dbl_kind, & ! constant in Hibler strength formula 
+         !Pstar = 2.75e4_dbl_kind, & ! constant in Hibler strength formula 
+         Pstar = 2.2e4_dbl_kind, & ! constant in Hibler strength formula 
                                  ! (kstrength = 0) 
          Cstar = c20             ! constant in Hibler strength formula 
                                  ! (kstrength = 0) 


### PR DESCRIPTION
Tuning the parameters (dragcofficient/Pstar) in CICE for TOPAZ5 reduces sea ice drift speed and increases the sea ice thickness a little.