### PR TITLE
Remove a bug for redundant 'ln' under SCRATCH

### DIFF
--- a/bin/expt_preprocess.sh
+++ b/bin/expt_preprocess.sh
@@ -633,7 +633,7 @@ else
 #     
    elif [ -f $D/${filename}_mem001.a -a -f $D/${filename}_mem001.b ]; then
       echo "using HYCOM restart files ${filename}_mem???.[ab] from data dir $D"
-      for f in ${plink} $D/${filename}_mem*.? ; do
+      for f in $D/${filename}_mem*.? ; do
          ${plink} $f .
       done
 


### PR DESCRIPTION
A small script bug was found in expt_process.sh. It has no actual impact on the ensemble model run, but results in noise for the valid file link by "ln -sf".