### PR TITLE
Shorten the filename of hourly CICE for output

### DIFF
--- a/cice/Release-5.1/source/ice_history_shared.F90
+++ b/cice/Release-5.1/source/ice_history_shared.F90
@@ -502,9 +502,9 @@
             history_file(1:lenstr(history_file)), &
              '.',iyear,'-',imonth,'-',iday,'.',suffix
           elseif (histfreq(ns) == 'h'.or.histfreq(ns) == 'H') then ! hourly
-           write(ncfile,'(a,a,i2.2,a,i4.4,a,i2.2,a,i2.2,a,i5.5,a,a)')  &
+           write(ncfile,'(a,a,i2.2,a,i4.4,a,i2.2,a,i2.2,a,i2.2,a,a)')  &
             history_file(1:lenstr(history_file)),'_',histfreq_n(ns),'h.', &
-             iyear,'-',imonth,'-',iday,'-',sec,'.',suffix
+             iyear,'-',imonth,'-',iday,'-',floor(sec/3600.),'.',suffix
           elseif (histfreq(ns) == 'm'.or.histfreq(ns) == 'M') then ! monthly
            write(ncfile,'(a,a,i4.4,a,i2.2,a,a)')  &
             history_file(1:lenstr(history_file)),'.', &

--- a/cice/Release-5.1/source/ice_history_shared.F90
+++ b/cice/Release-5.1/source/ice_history_shared.F90
@@ -450,6 +450,7 @@
                               year_init, new_year, new_month, new_day, &
                               dt
       use ice_restart_shared, only: lenstr
+      use ice_constants,      only: c3600
 
       character (char_len_long), intent(inout) :: ncfile
       character (len=2), intent(in) :: suffix

--- a/cice/Release-5.1/source/ice_history_shared.F90
+++ b/cice/Release-5.1/source/ice_history_shared.F90
@@ -504,7 +504,7 @@
           elseif (histfreq(ns) == 'h'.or.histfreq(ns) == 'H') then ! hourly
            write(ncfile,'(a,a,i2.2,a,i4.4,a,i2.2,a,i2.2,a,i2.2,a,a)')  &
             history_file(1:lenstr(history_file)),'_',histfreq_n(ns),'h.', &
-             iyear,'-',imonth,'-',iday,'-',floor(sec/3600.),'.',suffix
+             iyear,'-',imonth,'-',iday,'-',floor(sec/c3600),'.',suffix
           elseif (histfreq(ns) == 'm'.or.histfreq(ns) == 'M') then ! monthly
            write(ncfile,'(a,a,i4.4,a,i2.2,a,a)')  &
             history_file(1:lenstr(history_file)),'.', &


### PR DESCRIPTION
Modify the hourly CICE filename with a shorter suffix from 00 to 23.