### PR TITLE
Updates from upstream including relative winds

### DIFF
--- a/TP5a0.06/expt_02.3/blkdat.input
+++ b/TP5a0.06/expt_02.3/blkdat.input
@@ -106,6 +106,7 @@ S-Z(15-11): dp00/f/x/i=3m/1.125/12m/1m; ds=1m/1.125/4m; src_2.2.12;
    8.0    'hybrlx' = HYBGEN: inverse relaxation coefficient (time steps)
    0.01	  'hybiso' = HYBGEN: Use PCM if layer is within hybiso of target density
    1.0    'hybthn' = HYBGEN: ratio of layer thicknesses to select the thiner
+   0.0    'hybthk' = HYBGEN: thick-thin-thick ratio to expand the thin layer
    3	  'hybmap' = hybrid   remapper  flag (0=PCM, 1=PLM,  2=PPM)
    0	  'hybflg' = hybrid   generator flag (0=T&S, 1=th&S, 2=th&T)
    0	  'advflg' = thermal  advection flag (0=T&S, 1=th&S, 2=th&T)
@@ -205,6 +206,7 @@ S-Z(15-11): dp00/f/x/i=3m/1.125/12m/1m; ds=1m/1.125/4m; src_2.2.12;
    0.0	  'tid_t0' = TIDES: origin for ramp time (model day)
   12	  'clmflg' = climatology frequency flag   (6=bimonthly, 12=monthly)
    4	  'wndflg' = wind stress input flag (0=none,1=u/v-grid,2,3=p-grid,4,5=wnd10m)
+   1.0    'ocnscl' = scale factor for Uocn in relative wind (0.0: absolute wind)
    2      'ustflg' = ustar forcing     flag        (3=input,1,2=wndspd,4=stress)
    6	  'flxflg' = thermal forcing   flag (0=none,3=net_flux,1-2,4-6=sst-based)
    6      'empflg' = E-P     forcing   flag (0=none,3=net_E-P, 1-2,4-6=sst-based_E)

--- a/TP5a0.06/expt_02.3/blkdat.input_2.3
+++ b/TP5a0.06/expt_02.3/blkdat.input_2.3
@@ -106,6 +106,7 @@ S-Z(15-11): dp00/f/x/i=3m/1.125/12m/1m; ds=1m/1.125/4m; src_2.2.12;
    8.0    'hybrlx' = HYBGEN: inverse relaxation coefficient (time steps)
    0.01	  'hybiso' = HYBGEN: Use PCM if layer is within hybiso of target density
    1.0    'hybthn' = HYBGEN: ratio of layer thicknesses to select the thiner
+   0.0    'hybthk' = HYBGEN: thick-thin-thick ratio to expand the thin layer
    3	  'hybmap' = hybrid   remapper  flag (0=PCM, 1=PLM,  2=PPM)
    0	  'hybflg' = hybrid   generator flag (0=T&S, 1=th&S, 2=th&T)
    0	  'advflg' = thermal  advection flag (0=T&S, 1=th&S, 2=th&T)
@@ -205,6 +206,7 @@ S-Z(15-11): dp00/f/x/i=3m/1.125/12m/1m; ds=1m/1.125/4m; src_2.2.12;
    0.0	  'tid_t0' = TIDES: origin for ramp time (model day)
   12	  'clmflg' = climatology frequency flag   (6=bimonthly, 12=monthly)
    4	  'wndflg' = wind stress input flag (0=none,1=u/v-grid,2,3=p-grid,4,5=wnd10m)
+   1.0    'ocnscl' = scale factor for Uocn in relative wind (0.0: absolute wind)
    2      'ustflg' = ustar forcing     flag        (3=input,1,2=wndspd,4=stress)
    6	  'flxflg' = thermal forcing   flag (0=none,3=net_flux,1-2,4-6=sst-based)
    6      'empflg' = E-P     forcing   flag (0=none,3=net_E-P, 1-2,4-6=sst-based_E)

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/blkdat.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/blkdat.F90
@@ -1844,9 +1844,8 @@
 !
 ! --- 'clmflg' = climatology frequency flag (6=bimonthly,12=monthly)
 ! --- 'wndflg' = wind stress input flag (0=none,1=uv-grid,2,3=p-grid,4,5=wnd10m)
-! ---             (=3 wind speed from wind stress; =4,5 wind stress from wind)
+! ---             (=3 wind speed from wind stress; =4,5 relative wind stress from wind U10-Uocn)
 ! ---             (=4 for COARE 3.0; =5 for COREv2 bulk parameterization)
-! ---             (4,5 use relative wind U10-Uocn; -4,-5 use absolute wind U10)
 ! --- 'ocnscl' = scale factor for Uocn in relative wind (0.0: absolute wind)
 ! --- 'ustflg' = ustar forcing   flag          (3=input,1,2=wndspd,4=stress)
 ! --- 'flxflg' = thermal forcing flag   (0=none,3=net_flux,1-2,4-6=sst-based)
@@ -1877,11 +1876,11 @@
       call blkini(clmflg,'clmflg')
       call blkini(wndflg,'wndflg')
       call blkinr(ocnscl,'ocnscl','(a6," =",f10.4," ")')
-      if     (ocnscl.eq.0.0 .and. wndflg.ge.4) then
+      if (wndflg.lt.0 .or. wndflg.gt.5) then
         if (mnproc.eq.1) then
-        write(lp,'(/ a /)')  &
-         &'error - ocnscl must be >0.0 for relative winds (wndflg=4,5)'
-        call flush(lp)
+           write(lp,'(/ a /)')  &
+            &'error - wndflg must be between 0 and 5'
+            call flush(lp)
         endif !1st tile
         call xcstop('(blkdat)')
                stop '(blkdat)'
@@ -1895,12 +1894,7 @@
         call xcstop('(blkdat)')
                stop '(blkdat)'
       endif
-      wndflg = abs(wndflg)
-      if     (ocnscl.eq.0.0) then
-        amoflg = 0  !U10
-      else
-        amoflg = 1  !U10-Uocn
-      endif
+      wndflg = wndflg
       call blkini(ustflg,'ustflg')
       call blkini(flxflg,'flxflg')
       call blkini(empflg,'empflg')
@@ -1963,15 +1957,6 @@
         if (mnproc.eq.1) then
         write(lp,'(/ a /)')  &
           'error - sshflg must be 2 if baro nesting archives have this'
-        call flush(lp)
-        endif !1st tile
-        call xcstop('(blkdat)')
-               stop '(blkdat)'
-      endif
-      if (wndflg.lt.0 .or. wndflg.gt.5) then
-        if (mnproc.eq.1) then
-        write(lp,'(/ a /)')  &
-         &'error - wndflg must be between 0 and 5'
         call flush(lp)
         endif !1st tile
         call xcstop('(blkdat)')
@@ -2960,3 +2945,4 @@
 !> May  2024 - added epmass=2 for river only mass exchange
 !> Aug. 2024 - added ocnscl
 !> Sep. 2024 - added hybthk
+!> Dec. 2024 - Removed negative wndflg and amoflg due to inclusion of ocnscl

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/forfun.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/forfun.F90
@@ -325,7 +325,7 @@
           enddo !j
         endif !stroff:else
 !
-      endif				!  windf = .true.
+      endif     !  windf = .true.
 !
       if (thermo) then
 !

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/hybgen.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/hybgen.F90
@@ -331,7 +331,8 @@
       logical ltop                    !modify top layer
       real    p_hat,p_hat0,p_hat2,p_hat3,hybrlx, &
               delt,deltm,dels,delsm,q,qdep,qtr,qts,thkbop, &
-              zthk,dpthin
+              zthk,dpthin, &
+              dp_top,dp_cen,dp_bot,dp_far,dp_inc
       integer i,k,ka,kp,ktr,fixall,fixlay,nums1d
       character*12 cinfo
 !
@@ -1040,8 +1041,128 @@
 !
 ! ---     do not maintain constant thickness, k > fixlay
 !
-          if     (th3d(i,j,k,n).gt.theta(i,j,k)+epsil .and. &
-                  k.gt.fixlay+1) then 
+! TILL  The lower pressure should always be higher than the layer above.
+! A few exceptions has been found.
+          dp_top = p(i,j,k)   - p(i,j,k-1) + epsil
+          dp_cen = max(0.0,p(i,j,k+1) - p(i,j,k))   + epsil !NEEDED MODIFIED TILL
+          if     (k.eq.kdm) then
+            dp_bot = dp_cen  !disables thick-thin test
+            dp_far = dp_cen
+          elseif (k.eq.kdm-1) then
+            dp_bot = max(0.0,p(i,j,k+2) - p(i,j,k+1)) + epsil     ! NEEDED MODIFIED TILL
+            dp_far = dp_bot  !disables thick-2xthin test
+          else
+            dp_bot = p(i,j,k+2) - p(i,j,k+1) + epsil
+            dp_far = p(i,j,k+3) - p(i,j,k+2) + epsil
+          endif 
+          if     ( dp_cen .lt. hybthk*min(dp_top,dp_bot) ) then
+!
+! ---       thick-thin-thick layers with thin < hybthk*thick
+! ---       expand layer k with water from layers k-1 and k+1
+!
+            if     (min(dp_top,dp_bot) .lt. 0.2*max(dp_top,dp_bot) ) then
+! ---         weight by layer thicknesses, increment density is wrong
+              q = dp_top / (dp_top + dp_bot)
+            elseif (theta(i,j,k).gt.th3d(i,j,k-1,n) .and. &
+                    theta(i,j,k).lt.th3d(i,j,k+1,n)      ) then
+! ---         weight by actual densities, increment at theta(i,j,k)
+              q = (theta(i,j,k)-th3d(i,j,k+1,n))/ &
+               (th3d(i,j,k-1,n)-th3d(i,j,k+1,n))
+            else
+! ---         weight by target densities, increment density is approximate
+              q = (theta(i,j,k)-theta(i,j,k+1))/(theta(i,j,k-1)-theta(i,j,k+1))
+            endif
+! ---       allow for thick layers getting thinner
+            if     (dp_top .le. dp_bot) then
+              dp_inc = (hybthk*dp_top - dp_cen)/(1.0+q*hybthk)
+            else
+              dp_inc = (hybthk*dp_bot - dp_cen)/(1.0+(1.0-q)*hybthk)
+            endif
+            p_hat  = p(i,j,k) - q*dp_inc
+            p(i,j,k)=(1.0-qhrlx(k))*p(i,j,k) + &
+                          qhrlx(k) *p_hat
+            p_hat  = p(i,j,k+1) + (1.0-q)*dp_inc
+            p(i,j,k+1)=(1.0-qhrlx(k))*p(i,j,k+1) + &
+                            qhrlx(k) *p_hat
+!
+!diag           if (i.eq.itest .and. j.eq.jtest) then
+!diag             write(lp,'(a,3x,i2.2,4f10.3)') &
+!diag               'hybgen, thk,thnDP:',k,dp_top*qonem,dp_cen*qonem,dp_bot*qonem, &
+!diag                                      hybthk*min(dp_top,dp_bot)*qonem
+!diag             write(lp,'(a,3x,i2.2,f10.6,2f10.3,f10.5)') &
+!diag               'hybgen, thk,thn Q:',k,q,dp_inc*qonem, &
+!diag                (dp_inc+dp_cen)*qonem, &
+!diag                q*th3d(i,j,k-1,n)+(1.0-q)*th3d(i,j,k+1,n)
+!diag             dp_top = p(i,j,          k)    - p(i,j,k-1) + epsil
+!diag             dp_cen = p(i,j,          k+1)  - p(i,j,k)   + epsil
+!diag             dp_bot = p(i,j,min(kdm+1,k+2)) - p(i,j,k+1) + epsil
+!diag             write(lp,'(a,3x,i2.2,4f10.3)') &
+!diag               'hybgen, thk,thnNP:',k,dp_top*qonem,dp_cen*qonem,dp_bot*qonem, &
+!diag                                      hybthk*min(dp_top,dp_bot)*qonem
+!diag             call flush(lp)
+!diag           endif !debug
+!
+          elseif ( dp_cen+dp_bot .lt. hybthk*min(dp_top,dp_far) ) then
+!
+! ---       thick-thin-thin-thick layers with 2xthin < hybthk*thick
+! ---       expand layers k,k+1 with water from layers k-1 and k+2
+! ---       this should be rare
+!
+            if     (min(dp_top,dp_far) .lt. 0.2*max(dp_top,dp_far) ) then
+! ---         weight by layer thicknesses, increment density is wrong
+              q = dp_top / (dp_top + dp_far)
+            elseif (0.5*(theta(i,j,k)+theta(i,j,k+1)).gt.th3d(i,j,k-1,n) .and. &
+                    0.5*(theta(i,j,k)+theta(i,j,k+1)).lt.th3d(i,j,k+2,n)      ) then
+! ---         weight by actual densities, increment at 0.5*(theta(i,j,k)+theta(i,j,k+1))
+              q = (0.5*(theta(i,j,k)+theta(i,j,k+1))-th3d(i,j,k+2,n)) / &
+                  (th3d(i,j,k-1,n)-th3d(i,j,k+2,n))
+            else
+! ---         weight by target densities, increment density is approximate
+              q = (0.5*(theta(i,j,k)+theta(i,j,k+1))-theta(i,j,k+2)) / &
+                  (theta(i,j,k-1)-theta(i,j,k+2))
+            endif
+! ---       allow for thick layers getting thinner
+            if     (dp_top .le. dp_far) then
+              dp_inc = (hybthk*dp_top - (dp_cen+dp_bot))/(1.0+q*hybthk)
+            else
+              dp_inc = (hybthk*dp_far - (dp_cen+dp_bot))/(1.0+(1.0-q)*hybthk)
+            endif
+            p_hat  = p(i,j,k) - q*dp_inc
+            p(i,j,k)=(1.0-qhrlx(k))*p(i,j,k) + &
+                          qhrlx(k) *p_hat
+            p_hat  = p(i,j,k+2) + (1.0-q)*dp_inc
+            p(i,j,k+2)=(1.0-qhrlx(k))*p(i,j,k+2) + &
+                            qhrlx(k) *p_hat
+!
+!diag            if (i.eq.itest .and. j.eq.jtest) then
+!diag             if ( min(dp_top,dp_far) .lt. 0.2*max(dp_top,dp_far)) then
+!diag               write(lp,'(a,3x,i2.2,4f10.3)') &
+!diag                 'hybgen, thk,thnX2:',k,dp_top*qonem, &
+!diag                                        (dp_cen+dp_bot)*qonem,dp_far*qonem, &
+!diag                                        hybthk*min(dp_top,dp_far)*qonem
+!diag             else
+!diag               write(lp,'(a,3x,i2.2,4f10.3)') &
+!diag                 'hybgen, thk,thnD2:',k,dp_top*qonem, &
+!diag                                        (dp_cen+dp_bot)*qonem,dp_far*qonem, &
+!diag                                        hybthk*min(dp_top,dp_far)*qonem
+!diag             endif
+!diag             write(lp,'(a,3x,i2.2,f10.6,2f10.3,f10.5)') &
+!diag                 'hybgen, thk,thn Q:',k,q,dp_inc*qonem, &
+!diag                  (dp_inc+(dp_cen+dp_bot))*qonem, &
+!diag                  q*th3d(i,j,k-1,n)+(1.0-q)*th3d(i,j,k+2,n)
+!diag             dp_top = p(i,j,k)   - p(i,j,k-1) + epsil
+!diag             dp_cen = p(i,j,k+1) - p(i,j,k)   + epsil
+!diag             dp_bot = p(i,j,k+2) - p(i,j,k+1) + epsil
+!diag             dp_far = p(i,j,k+3) - p(i,j,k+2) + epsil
+!diag             write(lp,'(a,3x,i2.2,4f10.3)') &
+!diag               'hybgen, thk,thnNP:',k,dp_top*qonem, &
+!diag                                      (dp_cen+dp_bot)*qonem,dp_far*qonem, &
+!diag                                      hybthk*min(dp_top,dp_far)*qonem
+!diag             call flush(lp)
+!diag           endif !debug
+!
+          elseif (th3d(i,j,k,n).gt.theta(i,j,k)+epsil .and. &
+                  k.gt.fixlay+1) then
 !
 ! ---       water in layer k is too dense
 ! ---       try to dilute with water from layer k-1
@@ -1299,10 +1420,12 @@
 !
       enddo !k  vertical coordinate relocation
 
-      do k=1,kk-1
+      do k=2,kk-1
         ! If layer is too thick, move interface up
         if ((p(i,j,k+1)-p(i,j,k)) .gt. dx0k(k)) then
           p(i,j,k+1)=p(i,j,k)+dx0k(k)
+          lcm(k)   = .false.  !dx0k layers are never PCM
+          lcm(k-1) = .false.
 !
 !diag     if (i.eq.itest .and. j.eq.jtest) then
 !diag       write(lp,'(a,i3.2,f8.2)') &
@@ -2970,3 +3093,5 @@
 !> July 2023 - added trcflg=801: change in layer thickness   due to hybgen
 !> July 2023 - added trcflg=802: change in layer temperature due to hybgen
 !> July 2023 - added trcflg=803: change in layer salinity    due to hybgen
+!> Sep. 2024 - dx0k-ed layers are never remapped with PCM
+!> Sep. 2024 - added hybthk

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_barotp.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_barotp.F90
@@ -727,7 +727,7 @@
 !           Barotropic Stokes flow included here
 !
             pbudel = (ubavg(i+1,j,ml)+usdbavg(i+1,j))* &
-                          depthu(i+1,j)*scuy(i+1,j)) &
+                          (depthu(i+1,j)*scuy(i+1,j)) &
                     -(ubavg(i,  j,ml)+usdbavg(i,  j))* &
                            (depthu(i ,j)*scuy(i,  j))
             pbvdel = (vbavg(i,j+1,ml)+vsdbavg(i,j+1))* &

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_cb_arrays.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_cb_arrays.F90
@@ -352,7 +352,7 @@
 !
       logical, save :: &
                     btrlfr,btrmas,diagno,thermo,windf,mslprf, &
-                    pcipf,epmass,priver,rivera,kparan,lbmont, &
+                    pcipf,priver,rivera,kparan,lbmont, &
                     relax,srelax,trelax,trcrlx,relaxf,relaxs,relaxt, &
                     locsig,vsigma,hybrid,isopyc,icegln,hybraf,isopcm, &
                     mxl_no,mxlkta,mxlktb,mxlkrt,pensol, &
@@ -670,6 +670,7 @@
 ! ---'qhybrlx' = HYBGEN: relaxation coefficient (inverse baroclinic time steps)
 ! --- 'hybiso' = HYBGEN: Use PCM if layer is within hybiso of target density
 ! --- 'hybthn' = HYBGEN: ratio of layer thicknesses to select the thiner
+! --- 'hybthk' = HYBGEN: thick-thin-thick ratio to expand the thin layer
 ! --- 'visco2' = deformation-dependent Laplacian  viscosity factor
 ! --- 'visco4' = deformation-dependent biharmonic viscosity factor
 ! --- 'facdf4' =       speed-dependent biharmonic viscosity factor
@@ -722,6 +723,7 @@
 ! --- 'thkbot' = thickness of bottom boundary layer (m)
 ! --- 'sigjmp' = minimum density jump across interfaces   (theta units)
 ! --- 'tmljmp' = equivalent temperature jump across the mixed layer (degC)
+! --- 'ocnscl' = scale factor for Uocn in relative wind (0.0 for absolute wind)
 ! --- 'prsbas' = msl pressure is input field + prsbas (Pa)
 ! --- 'salmin' = minimum salinity allowed in an isopycnic layer (psu)
 ! --- 'dx00'   = maximum layer thickness minimum, optional (m)
@@ -780,6 +782,7 @@
 ! --- 'sstflg' = SST relaxation  flag (0=none,1=clim,2=atmos,3=obs)
 ! --- 'icmflg' = ice mask        flag (0=none,1=clim,2=atmos,3=obs)
 ! --- 'difsmo' = KPROF: number of layers with horiz smooth diff coeffs
+! --- 'epmass' = E-P mass exchange flag (0=no,1=yes,2=river)
 !
 #if defined(RELO)
       real, save, allocatable, dimension(:) ::  &
@@ -791,7 +794,7 @@
 !
       real, save :: &
                      thbase,saln0,baclin,batrop, &
-                     qhybrlx,hybiso,hybthn, &
+                     qhybrlx,hybiso,hybthn,hybthk, &
                      visco2,visco4,veldf2,veldf4,facdf4, &
                      temdf2,temdfc,thkdf2,thkdf4,vertmx,diapyc, &
                      tofset,sofset,dtrate,slip,cb,cbar, &
@@ -804,7 +807,7 @@
                      thkcdw,thkfrz,tfrz_0,tfrz_s,ticegr,hicemn,hicemx, &
                      dx00,dx00f,dx00x, &
                      dp00,dp00f,dp00x,ds00,ds00f,ds00x,dp00i,isotop, &
-                     oneta0,sigjmp,tmljmp,prsbas,emptgt
+                     oneta0,sigjmp,tmljmp,ocnscl,prsbas,emptgt
 !
       integer, save :: &
                      tsofrq,mixfrq,icefrq,icpfrq,nhybrd,nsigma, &
@@ -815,7 +818,7 @@
                      iversn,iexpt,jerlv0, &
                      iceflg,ishelf,icmflg,wndflg,amoflg,ustflg, &
                      flxflg,empflg,dswflg,albflg,lwflag,sstflg,sssflg, &
-                     empbal,sssbal, &
+                     epmass,empbal,sssbal, &
                      difsmo,disp_count
 !
       real,    parameter :: &
@@ -1923,3 +1926,6 @@
 !> July 2023 - added mtracr and itracr
 !> Sep. 2023 - initialize si_h to zero
 !> Jan. 2024 - added pbotmin
+!> May  2024 - added epmass=2 for river only mass exchange
+!> Aug. 2024 - added ocnscl
+!> Sep. 2024 - added hybthk

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_cb_arrays.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_cb_arrays.F90
@@ -769,7 +769,6 @@
 ! --- 'iceflg' = sea ice model flag   (0=none,1=energy loan,2=coupled/esmf)
 ! --- 'ishelf' = ice shelf flag       (0=none,1=ice shelf over ocean)
 ! --- 'wndflg' = wind stress input flag (0=none,1=uv-grid,2,3=p-grid,4,5=wnd10m)
-! --- 'amoflg' = relative wind     flag (0=U10:wndflg=-4,-5;1=U10-Uocn:wndflg=4,5)
 ! --- 'ustflg' = ustar forcing flag          (3=input,1=wndspd,2=stress)
 ! --- 'flxflg' = thermal forcing flag (0=none,3=net-flux,1,2,4=sst-based)
 ! --- 'empflg' = E-P     forcing flag (0=none,3=net_E-P, 1,2,4=sst-based_E)
@@ -816,7 +815,7 @@
                      ntracr,mtracr,trcflg(mxtrcr),itracr(801:899), &
                      clmflg,dypflg,iniflg,lbflag,mapflg,yrflag,sshflg, &
                      iversn,iexpt,jerlv0, &
-                     iceflg,ishelf,icmflg,wndflg,amoflg,ustflg, &
+                     iceflg,ishelf,icmflg,wndflg,ustflg, &
                      flxflg,empflg,dswflg,albflg,lwflag,sstflg,sssflg, &
                      epmass,empbal,sssbal, &
                      difsmo,disp_count
@@ -1929,3 +1928,4 @@
 !> May  2024 - added epmass=2 for river only mass exchange
 !> Aug. 2024 - added ocnscl
 !> Sep. 2024 - added hybthk
+!> Dec. 2024 - removed amoflg

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_momtum.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_momtum.F90
@@ -90,7 +90,13 @@
 ! --- -----------------------------------------
 !
       logical, parameter :: lpipe_momtum=.false.      !usually .false.
-
+!
+#if defined (USE_NUOPC_CESMBETA)
+      logical, parameter ::  cesmbeta =.true.
+#else
+      logical, parameter ::  cesmbeta =.false.
+#endif
+!
 ! Reduced dragw_rho to half in order to align with CICE
       real,    parameter :: dragw_rho=0.00536d0*1026.0d0  !ice-ocean drag from CICE
 !     real,    parameter :: dragw_rho=0.01072d0*1026.0d0  !ice-ocean drag original
@@ -388,7 +394,7 @@
               endif !usur,vsur
 !
               if     (wndflg.eq.2 .or. wndflg.eq.3) then ! tau on p grid
-                if (cpl_taux) then
+                if (cesmbeta .and. cpl_taux) then
                   surtx(i,j) = imp_taux(i,j,1)
                 elseif (natm.eq.2) then
                   surtx(i,j) = taux(i,j,l0)*w0+taux(i,j,l1)*w1
@@ -397,7 +403,7 @@
                              + taux(i,j,l2)*w2+taux(i,j,l3)*w3
                 endif ! cpl_taux
 
-                if (cpl_tauy) then
+                if (cesmbeta .and. cpl_tauy) then
                   surty(i,j) = imp_tauy(i,j,1)
                 elseif (natm.eq.2) then
                   surty(i,j) = tauy(i,j,l0)*w0+tauy(i,j,l1)*w1
@@ -491,11 +497,13 @@
                 if     (wndflg.eq.4 .and. flxflg.eq.6) then
                   if     (amoflg.ne.0) then
 ! ---               use wind-current in place of wind for everything
-                    samo  = sqrt( (wndx-usur)**2 + (wndy-vsur)**2 )
+! ---               set ocnscl to 1.0 for full relative wind
+                    samo  = sqrt( (wndx-ocnscl*usur)**2 +&
+                                  (wndy-ocnscl*vsur)**2 )
                     cdw   = 1.0e-3*cd_coarep(samo,vpmx,airt,pair, &
                                              temp(i,j,1,n))
-                    surtx( i,j) = rair*cdw*samo*(wndx-usur)
-                    surty( i,j) = rair*cdw*samo*(wndy-vsur)
+                    surtx( i,j) = rair*cdw*samo*(wndx-ocnscl*usur)
+                    surty( i,j) = rair*cdw*samo*(wndy-ocnscl*vsur)
                     wndocn(i,j) = samo  !save for thermf
                   else
 ! ---               use wind for everything
@@ -509,9 +517,11 @@
                                           temp(i,j,1,n))
                   if     (amoflg.ne.0) then
 ! ---               use wind-current magnitude and direction for stress 
-                    samo = sqrt( (wndx-usur)**2 + (wndy-vsur)**2 )
-                    surtx(i,j) = rair*cdw*samo*(wndx-usur)
-                    surty(i,j) = rair*cdw*samo*(wndy-vsur)
+! ---               set ocnscl to 1.0 for full relative wind
+                    samo = sqrt( (wndx-ocnscl*usur)**2 +&
+                                 (wndy-ocnscl*vsur)**2 )
+                    surtx(i,j) = rair*cdw*samo*(wndx-ocnscl*usur)
+                    surty(i,j) = rair*cdw*samo*(wndy-ocnscl*vsur)
                   else
 ! ---               use wind for everything
                     surtx(i,j) = rair*cdw*wind*wndx
@@ -523,9 +533,11 @@
                                           temp(i,j,1,n))
                   if     (amoflg.ne.0) then
 ! ---               use wind-current magnitude and direction for stress 
-                    samo = sqrt( (wndx-usur)**2 + (wndy-vsur)**2 )
-                    surtx(i,j) = rair*cdw*samo*(wndx-usur)
-                    surty(i,j) = rair*cdw*samo*(wndy-vsur)
+! ---               set ocnscl to 1.0 for full relative wind
+                    samo = sqrt( (wndx-ocnscl*usur)**2 +&
+                                 (wndy-ocnscl*vsur)**2 )
+                    surtx(i,j) = rair*cdw*samo*(wndx-ocnscl*usur)
+                    surty(i,j) = rair*cdw*samo*(wndy-ocnscl*vsur)
                   else
 ! ---               use U10 magnitude and direction for stress 
                     surtx(i,j) = rair*cdw*wind*wndx
@@ -1077,12 +1089,25 @@
 !
       logical, parameter :: lpipe_momtum=.false.  !usually .false.
 !
+#if defined(MOMTUM_CFL)
+      logical, parameter :: momtum_cfl=.true.     !set by a CPP macro
+                                                  !include an explicit CFL limiter
+#else
+      logical, parameter :: momtum_cfl=.false.    !usually .false.
+                                                  !include an explicit CFL limiter
+#endif
+      real,    parameter :: clip_min=0.5          !minimum clipping to report
+!
 #if defined(RELO)
       real, save, allocatable, dimension(:,:) :: &
                        vis2u,vis4u,vis2v,vis4v,vort, &
                        wgtia,wgtib,wgtja,wgtjb, &
                        dl2u,dl2uja,dl2ujb,dl2v,dl2via,dl2vib, &
                        pnk0,pnkp,stresl
+      real, save, allocatable, dimension(:,:) :: &
+       uvjclp
+      real, save, allocatable, dimension(:) :: &
+       uvkmax
 #else
       real, dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: &
                        vis2u,vis4u,vis2v,vis4v,vort, &
@@ -1095,6 +1120,10 @@
                        dl2u,dl2uja,dl2ujb,dl2v,dl2via,dl2vib, &
                        pnk0,pnkp,stresl
       save  /momtumr4/
+      real, save, dimension(1-nbdy:jdm+nbdy,1:kdm) :: &
+       uvjclp
+      real, save, dimension(1:kdm) :: &
+       uvkmax=clip_min
 #endif
 !
 #if defined(STOKES)
@@ -1112,10 +1141,9 @@
 #endif
                   dvdzu,dudzu,dvdzv,dudzv,dzdx,dzdy
 !
-
       real    uatvk0,uatvkm,uatvkp,usd_v,vatuk0,vatukm,vatukp,vsd_u, &
               zbot,ztop
-
+!
 #endif /* STOKES */
       integer, save :: ifirst
 !
@@ -1126,6 +1154,7 @@
            dmontg,dthstr,dragu,dragv,qdpu,qdpv,dpthin, &
            dpun,uhm,uh0,uhp,dpvn,vhm,vh0,vhp,sum_m,sum_n
       real dp12,dp23,dp123,dp3m1,ql1,ql2,ql3
+      real cfl,uvclpm,uvclpn,uvkclp(kdm)
       integer i,ia,ib,j,ja,jb,k,ka,l,mbdy,ktop,kmid,kbot,margin
 !
 !     real*8    wtime
@@ -1184,6 +1213,16 @@
                   pnk0 = 0.0  !r_init
                   pnkp = 0.0  !r_init
                 stresl = 0.0  !r_init
+        if     (momtum_cfl) then
+          allocate( &
+                   uvjclp(1-nbdy:jdm+nbdy,1:kdm) )
+          call mem_stat_add( (jdm+2*nbdy)*kdm )
+                   uvjclp = 0.0
+          allocate( &
+                   uvkmax(1:kdm) )
+          call mem_stat_add( kdm )
+                   uvkmax = clip_min
+        endif !cfl
       endif !vis2u
 #if defined(STOKES)
       if     (.not.allocated(usdflux)) then
@@ -2956,16 +2995,31 @@
 ! --- extract barotropic velocities generated during most recent 
 ! --- baroclinic time step and use them to force barotropic flow field.
 !
+      if     (momtum_cfl) then
+        uvjclp(:,:) = 0.0
+      endif
+!
       margin = 0
 !
-!$OMP PARALLEL DO PRIVATE(j,i,k,q,sum_m,sum_n) &
+!$OMP PARALLEL DO PRIVATE(j,i,k,q,sum_m,sum_n,cfl,uvclpm,uvclpn) &
 !$OMP          SCHEDULE(STATIC,jblk)
       do j=1-margin,jj+margin
         do i=1-margin,ii+margin
+! ---     limit is conservative, so clipping occurs before CFL is exceedd
+          cfl = 0.707*0.5*min(scpx(i,j),scpy(i,j))/delt1
           if (SEA_U) then
             k=1
               u(i,j,k,m) = u(i,j,k,m)/max(dpu(i,j,k,m),dpthin)
               u(i,j,k,n) = u(i,j,k,n)/max(dpu(i,j,k,n),dpthin)
+              if     (momtum_cfl) then  !this should not be needed
+                uvclpm = abs(u(i,j,k,m))
+                uvclpn = abs(u(i,j,k,n))
+                u(i,j,k,m) = max( -cfl, min( cfl, u(i,j,k,m) ) )
+                u(i,j,k,n) = max( -cfl, min( cfl, u(i,j,k,n) ) )
+                uvclpm = uvclpm - abs(u(i,j,k,m))
+                uvclpn = uvclpn - abs(u(i,j,k,n))
+                uvjclp(j,k) = max( uvjclp(j,k), uvclpm, uvclpn)
+              endif !cfl
               sum_m      = u(i,j,k,m)*    dpu(i,j,k,m)
               sum_n      = u(i,j,k,n)*    dpu(i,j,k,n)
             do k=2,kk
@@ -2977,6 +3031,15 @@
               q          = min(dpu(i,j,k,n),cutoff)
               u(i,j,k,n) = (u(i,j,k,n)*q+u(i,j,k-1,n)*(cutoff-q))* &
                            qcutoff
+              if     (momtum_cfl) then  !this should not be needed
+                uvclpm = abs(u(i,j,k,m))
+                uvclpn = abs(u(i,j,k,n))
+                u(i,j,k,m) = max( -cfl, min( cfl, u(i,j,k,m) ) )
+                u(i,j,k,n) = max( -cfl, min( cfl, u(i,j,k,n) ) )
+                uvclpm = uvclpm - abs(u(i,j,k,m))
+                uvclpn = uvclpn - abs(u(i,j,k,n))
+                uvjclp(j,k) = max( uvjclp(j,k), uvclpm, uvclpn)
+              endif !cfl
               sum_m      = sum_m + u(i,j,k,m)*dpu(i,j,k,m)
               sum_n      = sum_n + u(i,j,k,n)*dpu(i,j,k,n)
             enddo !k
@@ -2995,6 +3058,15 @@
             k=1
               v(i,j,k,m) = v(i,j,k,m)/max(dpv(i,j,k,m),dpthin)
               v(i,j,k,n) = v(i,j,k,n)/max(dpv(i,j,k,n),dpthin)
+              if     (momtum_cfl) then  !this should not be needed
+                uvclpm = abs(v(i,j,k,m))
+                uvclpn = abs(v(i,j,k,n))
+                v(i,j,k,m) = max( -cfl, min( cfl, v(i,j,k,m) ) )
+                v(i,j,k,n) = max( -cfl, min( cfl, v(i,j,k,n) ) )
+                uvclpm = uvclpm - abs(v(i,j,k,m))
+                uvclpn = uvclpn - abs(v(i,j,k,n))
+                uvjclp(j,k) = max( uvjclp(j,k), uvclpm, uvclpn)
+              endif !cfl
               sum_m      = v(i,j,1,m)*    dpv(i,j,1,m)
               sum_n      = v(i,j,1,n)*    dpv(i,j,1,n)
             do k=2,kk
@@ -3006,6 +3078,15 @@
               q          = min(dpv(i,j,k,n),cutoff)
               v(i,j,k,n) = (v(i,j,k,n)*q+v(i,j,k-1,n)*(cutoff-q))* &
                            qcutoff
+              if     (momtum_cfl) then  !this should not be needed
+                uvclpm = abs(v(i,j,k,m))
+                uvclpn = abs(v(i,j,k,n))
+                v(i,j,k,m) = max( -cfl, min( cfl, v(i,j,k,m) ) )
+                v(i,j,k,n) = max( -cfl, min( cfl, v(i,j,k,n) ) )
+                uvclpm = uvclpm - abs(v(i,j,k,m))
+                uvclpn = uvclpn - abs(v(i,j,k,n))
+                uvjclp(j,k) = max( uvjclp(j,k), uvclpm, uvclpn)
+              endif !cfl
               sum_m      = sum_m + v(i,j,k,m)*dpv(i,j,k,m)
               sum_n      = sum_n + v(i,j,k,n)*dpv(i,j,k,n)
             enddo !k
@@ -3022,6 +3103,30 @@
         enddo !i
       enddo !j - do 30 loop
 !$OMP END PARALLEL DO
+!
+! --- check for velocity clipping at cfl limit
+!
+      if     (momtum_cfl .and. mod(nstep,3).eq.0) then  !skip some time steps for efficiency
+        do k= 1,kk
+          uvkclp(k) = 0.0
+          do j=1,jj
+            uvkclp(k) = max( uvkclp(k), uvjclp(j,k) )
+          enddo !j
+        enddo !k
+        call xcmaxr(uvkclp(1:kk))
+        do k= 1,kk
+          if     (uvkclp(k).gt.uvkmax(k)) then
+            if     (mnproc.eq.1) then
+              write(lp, &
+                '(i9,a,i3,a,f7.2,a)') &
+                nstep,' k=',k, &
+                ' velocty clipped, max=',uvkclp(k),' m/s'
+            endif !mnproc
+            uvkmax(k) = uvkclp(k)
+          endif
+        enddo !k
+        call xcsync(flush_lp)
+      endif !every 3 time steps
 !
       if     (lpipe .and. lpipe_momtum) then
 ! ---   compare two model runs.
@@ -5401,8 +5506,9 @@
 !$OMP          SCHEDULE(STATIC,jblk)
       do j=1-margin,jj+margin
         do i=1-margin,ii+margin
+! ---     limit is conservative, so clipping occurs before CFL is exceedd
+          cfl = 0.707*0.5*min(scpx(i,j),scpy(i,j))/delt1
           if (SEA_U) then
-            cfl = 0.5*min(scpx(i,j),scpy(i,j))/delt1
             k=1
               u(i,j,k,m) = u(i,j,k,m)/max(dpu(i,j,k,m),dpthin)
               u(i,j,k,n) = u(i,j,k,n)/max(dpu(i,j,k,n),dpthin)
@@ -5438,11 +5544,8 @@
 !
             utotn(i,j) = dt1inv*(sum_n - ubavg(i,j,n))  !for barotp
           endif !iu
-        enddo !i
 !
-        do i=1-margin,ii+margin
           if (SEA_V) then
-            cfl = 0.5*min(scpx(i,j),scpy(i,j))/delt1
             k=1
               v(i,j,k,m) = v(i,j,k,m)/max(dpv(i,j,k,m),dpthin)
               v(i,j,k,n) = v(i,j,k,n)/max(dpv(i,j,k,n),dpthin)
@@ -5627,3 +5730,6 @@
 !> Sep. 2019 - added momtum_init
 !> Oct. 2019 - placed momtum4_cfl in a CPP macro
 !> Nov. 2019 - added amoflg for U10 vs U10-Uocn
+!> Mar. 2023 - added momtum_cfl in a CPP macro
+!> Dec. 2023 - add cesmbeta as a master switch to cpl_
+!> Aug. 2024 - replace U10-Uocn with U10-ocnscl*Uocn

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_momtum.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_momtum.F90
@@ -370,7 +370,7 @@
         do j=1-margin,jj+margin
           do i=1-margin,ii+margin
             if (SEA_P) then
-              if     (amoflg.ne.0 .or. &
+              if     (ocnscl.ne.0.0 .or. &
                       (iceflg.eq.2 .and. si_c(i,j).gt.0.0)) then
 ! ---           average currents over top thkcdw meters
                 thksur = onem*min( thkcdw, depths(i,j) )
@@ -495,7 +495,7 @@
                 endif
 !
                 if     (wndflg.eq.4 .and. flxflg.eq.6) then
-                  if     (amoflg.ne.0) then
+                  if     (ocnscl.ne.0.0) then
 ! ---               use wind-current in place of wind for everything
 ! ---               set ocnscl to 1.0 for full relative wind
                     samo  = sqrt( (wndx-ocnscl*usur)**2 +&
@@ -508,14 +508,14 @@
                   else
 ! ---               use wind for everything
                     cdw   = 1.0e-3*cd_coarep(wind,vpmx,airt,pair, &
-                                             temp(i,j,1,n))
+                                              temp(i,j,1,n))
                     surtx( i,j) = rair*cdw*wind*wndx
                     surty( i,j) = rair*cdw*wind*wndy
-                  endif !amoflg
+                  endif !ocnscl
                 elseif (wndflg.eq.4) then
                   cdw  = 1.0e-3*cd_coare(wind,vpmx,airt, &
-                                          temp(i,j,1,n))
-                  if     (amoflg.ne.0) then
+                                         temp(i,j,1,n))
+                  if     (ocnscl.ne.0.0) then
 ! ---               use wind-current magnitude and direction for stress 
 ! ---               set ocnscl to 1.0 for full relative wind
                     samo = sqrt( (wndx-ocnscl*usur)**2 +&
@@ -526,12 +526,12 @@
 ! ---               use wind for everything
                     surtx(i,j) = rair*cdw*wind*wndx
                     surty(i,j) = rair*cdw*wind*wndy
-                  endif !amoflg
+                  endif !ocnscl
                 else  ! wndflg.eq.5
 ! ---             vpmx assumed to contain specific humidity
                   cdw  = 1.0e-3*cd_core2(wind,vpmx,airt, &
                                           temp(i,j,1,n))
-                  if     (amoflg.ne.0) then
+                  if     (ocnscl.ne.0.0) then
 ! ---               use wind-current magnitude and direction for stress 
 ! ---               set ocnscl to 1.0 for full relative wind
                     samo = sqrt( (wndx-ocnscl*usur)**2 +&
@@ -539,10 +539,10 @@
                     surtx(i,j) = rair*cdw*samo*(wndx-ocnscl*usur)
                     surty(i,j) = rair*cdw*samo*(wndy-ocnscl*vsur)
                   else
-! ---               use U10 magnitude and direction for stress 
+! ---               use U10 magnitude and direction for stress
                     surtx(i,j) = rair*cdw*wind*wndx
                     surty(i,j) = rair*cdw*wind*wndy
-                  endif !amoflg
+                  endif
                 endif
 
               endif !wndflg
@@ -5733,3 +5733,4 @@
 !> Mar. 2023 - added momtum_cfl in a CPP macro
 !> Dec. 2023 - add cesmbeta as a master switch to cpl_
 !> Aug. 2024 - replace U10-Uocn with U10-ocnscl*Uocn
+!> Dec. 2024 - Replace amoflg with ocnscl 

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mxkprf.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mxkprf.F90
@@ -696,13 +696,17 @@
             sflux1=surflx(i,j)-sswflx(i,j)
             dtemp=(sflux1+(1.-swfrac(k+1))*sswflx(i,j))* &
                   delt1*g*qspcifh*(qdpmm(k)*qoneta)
-            if (epmass) then  !only actual salt flux
+            if     (epmass.eq.1) then  !only actual salt flux
               dsaln= salflx(i,j)* &
-                    delt1*g*        (qdpmm(k)*qoneta)
+                    delt1*g*(qdpmm(k)*qoneta)
+            elseif (epmass.eq.2) then  !river only is mass flux
+              dsaln=(salflx(i,j)- &
+                     (wtrflx(i,j)-rivflx(i,j))*saln(i,j,1,n))* &
+                    delt1*g*(qdpmm(k)*qoneta)
             else  !water flux treated as a virtual salt flux
               dsaln=(salflx(i,j)-wtrflx(i,j)*saln(i,j,1,n))* &
-                    delt1*g*        (qdpmm(k)*qoneta)
-            endif
+                    delt1*g*(qdpmm(k)*qoneta)
+            endif !epmass
 !diag       if (i.eq.itest.and.j.eq.jtest) then
 !diag         write (lp,101) nstep,i+i0,j+j0,k,  &
 !diag           1.0,swfrac(k+1),dtemp,dsaln
@@ -2224,13 +2228,17 @@
             sflux1=surflx(i,j)-sswflx(i,j)
             dtemp=(sflux1+(1.-swfrac(k+1))*sswflx(i,j))* &
                   delt1*g*qspcifh*(qdpmm(k)*qoneta)
-            if (epmass) then  !only actual salt flux
+            if     (epmass.eq.1) then  !only actual salt flux
               dsaln= salflx(i,j)* &
-                    delt1*g*        (qdpmm(k)*qoneta)
+                    delt1*g*(qdpmm(k)*qoneta)
+            elseif (epmass.eq.2) then  !river only is mass flux
+              dsaln=(salflx(i,j)- &
+                     (wtrflx(i,j)-rivflx(i,j))*saln(i,j,1,n))* &
+                    delt1*g*(qdpmm(k)*qoneta)
             else  !water flux treated as a virtual salt flux
               dsaln=(salflx(i,j)-wtrflx(i,j)*saln(i,j,1,n))* &
-                    delt1*g*        (qdpmm(k)*qoneta)
-            endif
+                    delt1*g*(qdpmm(k)*qoneta)
+            endif !epmass
 !diag       if (i.eq.itest .and. j.eq.jtest) then
 !diag         write (lp,102) nstep,i+i0,j+j0,k,  &
 !diag           0.,1.-swfrac(k+1),dtemp,dsaln
@@ -2469,13 +2477,17 @@
             sflux1=surflx(i,j)-sswflx(i,j)
             dtemp=(sflux1+(1.-swfrac(k+1))*sswflx(i,j))* &
                   delt1*g*qspcifh*(qdpmm(k)*qoneta)
-            if (epmass) then  !only actual salt flux
+            if     (epmass.eq.1) then  !only actual salt flux
               dsaln= salflx(i,j)* &
-                    delt1*g*        (qdpmm(k)*qoneta)
+                    delt1*g*(qdpmm(k)*qoneta)
+            elseif (epmass.eq.2) then  !river only is mass flux
+              dsaln=(salflx(i,j)- &
+                     (wtrflx(i,j)-rivflx(i,j))*saln(i,j,1,n))* &
+                    delt1*g*(qdpmm(k)*qoneta)
             else  !water flux treated as a virtual salt flux
               dsaln=(salflx(i,j)-wtrflx(i,j)*saln(i,j,1,n))* &
-                    delt1*g*        (qdpmm(k)*qoneta)
-            endif
+                    delt1*g*(qdpmm(k)*qoneta)
+            endif !epmass
 !diag       if (i.eq.itest.and.j.eq.jtest) then
 !diag         write (lp,101) nstep,i+i0,j+j0,k, &
 !diag           0.,1.-swfrac(k+1),dtemp,dsaln
@@ -3876,3 +3888,4 @@
 !> Dec  2018 - added /* USE_NUOPC_CESMBETA */ macro and riv_input
 !> Mar  2023 - added /* MASSLESS_1MM */ macro
 !> July 2023 - detrain negative near-surface salinitites
+!> May  2024 - added epmass=2 for river only mass exchange

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mxkrt.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mxkrt.F90
@@ -454,8 +454,12 @@
         sflux1=surflx(i,j)-sswflx(i,j)
         dtemp(i)=(sflux1+(1.-swfrac)*sswflx(i,j))* &
                  delt1*g/(spcifh*thk1ta)
-        if (epmass) then  !only actual salt flux
+        if     (epmass.eq.1) then  !only actual salt flux
           dsaln(i)= salflx(i,j)* &
+                   delt1*g/thk1ta
+        elseif (epmass.eq.2) then  !river only is mass flux
+          dsaln(i)=(salflx(i,j)- &
+                    (wtrflx(i,j)-rivflx(i,j))*saln(i,j,1,n))* &
                    delt1*g/thk1ta
         else  !water flux treated as a virtual salt flux
           dsaln(i)=(salflx(i,j)-wtrflx(i,j)*saln(i,j,1,n))* &
@@ -470,8 +474,12 @@
 !
         dtemp(i)=surflx(i,j)* &
                  delt1*g/(spcifh*thk1ta)
-        if (epmass) then  !only actual salt flux
+        if     (epmass.eq.1) then  !only actual salt flux
           dsaln(i)= salflx(i,j)* &
+                   delt1*g/thk1ta
+        elseif (epmass.eq.2) then  !river only is mass flux
+          dsaln(i)=(salflx(i,j)- &
+                    (wtrflx(i,j)-rivflx(i,j))*saln(i,j,1,n))* &
                    delt1*g/thk1ta
         else  !water flux treated as a virtual salt flux
           dsaln(i)=(salflx(i,j)-wtrflx(i,j)*saln(i,j,1,n))* &
@@ -1249,3 +1257,4 @@
 !> Nov. 2018 - added wtrflx, salflx now only actual salt flux
 !> Nov. 2018 - allow for wtrflx in buoyancy flux 
 !> Nov. 2018 - allow for oneta in swfrac and surface fluxes
+!> May  2024 - added epmass=2 for river only mass exchange

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mxkrtm.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mxkrtm.F90
@@ -419,8 +419,11 @@
 !
       do i=1,ii
       if (SEA_P) then
-        if (epmass) then  !only actual salt flux
+        if      (epmass.eq.1) then  !only actual salt flux
           vsflx(i)= salflx(i,j)
+        elseif (epmass.eq.2) then  !river only is mass flux
+          vsflx(i)=(salflx(i,j)- &
+                    (wtrflx(i,j)-rivflx(i,j))*saln(i,j,1,n))
         else !water flux treated as a virtual salt flux
           vsflx(i)=(salflx(i,j)-wtrflx(i,j)*saln(i,j,1,n))
         endif
@@ -667,3 +670,4 @@
 !> May  2014 - use land/sea masks (e.g. ip) to skip land
 !> Aug. 2018 - added wtrflx, salflx now only actual salt flux
 !> Nov. 2018 - allow for wtrflx in buoyancy flux 
+!> May  2024 - added epmass=2 for river only mass exchange

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mxpwp.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mxpwp.F90
@@ -289,8 +289,12 @@
               sflux1=surflx(i,j)-sswflx(i,j)
               dtemp=(sflux1+(1.-swfrac(k+1))*sswflx(i,j))* &
                     delt1*g*qoneta/(spcifh*max(onemm,dp1d(k)))
-              if (epmass) then  !only actual salt flux
+              if     (epmass.eq.1) then  !only actual salt flux
                 dsaln= salflx(i,j)* &
+                      delt1*g*qoneta/max(onemm,dp1d(k))
+              elseif (epmass.eq.2) then  !river only is mass flux
+                dsaln=(salflx(i,j)- &
+                       (wtrflx(i,j)-rivflx(i,j))*saln(i,j,1,n))* &
                       delt1*g*qoneta/max(onemm,dp1d(k))
               else  !water flux treated as a virtual salt flux
                 dsaln=(salflx(i,j)-wtrflx(i,j)*saln(i,j,1,n))* &
@@ -305,8 +309,12 @@
             else !.not.pensol
               dtemp=surflx(i,j)* &
                     delt1*g*qoneta/(spcifh*max(onemm,dp1d(k)))
-              if (epmass) then  !only actual salt flux
+              if     (epmass.eq.1) then  !only actual salt flux
                 dsaln= salflx(i,j)* &
+                      delt1*g*qoneta/max(onemm,dp1d(k))
+              elseif (epmass.eq.2) then  !river only is mass flux
+                dsaln=(salflx(i,j)- &
+                       (wtrflx(i,j)-rivflx(i,j))*saln(i,j,1,n))* &
                       delt1*g*qoneta/max(onemm,dp1d(k))
               else  !water flux treated as a virtual salt flux
                 dsaln=(salflx(i,j)-wtrflx(i,j)*saln(i,j,1,n))* &
@@ -811,3 +819,4 @@
 !> May  2014 - use land/sea masks (e.g. ip) to skip land
 !> Aug. 2018 - added wtrflx, salflx now only actual salt flux
 !> Nov. 2018 - allow for oneta in swfrac and surface fluxes
+!> May  2024 - added epmass=2 for river only mass exchange

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/thermf.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/thermf.F90
@@ -40,14 +40,14 @@
       real*8  d1,d2,d3,d4,ssum(2),s1(2)
 !
       if     (ishelf.ne.0) then  !sea ice and an ice shelf
-!$OMP PARALLEL DO PRIVATE(j,i)
+!$OMP   PARALLEL DO PRIVATE(j,i) &
+!$OMP            SCHEDULE(STATIC,jblk)
         do j=1,jj
           do i=1,ii
             if (SEA_P) then
               if     (ishlf(i,j).eq.1) then  !standard ocean point
                 if ( cpl_swflx  .and. cpl_lwmdnflx .and. cpl_lwmupflx &
                                 .and. cpl_precip   .and. cesmbeta ) then
-
                   sstflx(i,j) = (1.0-covice(i,j))*sstflx(i,j)   !relax over ocean
                   surflx(i,j) =     surflx(i,j) + flxice(i,j)   !ocn/ice frac. in coupler
                   salflx(i,j) =                   sflice(i,j) +  & !ocn/ice frac. in coupler
@@ -55,7 +55,6 @@
                   wtrflx(i,j) =     wtrflx(i,j) + wflice(i,j) +  & !ocn/ice frac. in coupler
                                                   rivflx(i,j)   !rivers evrywhere 
                 else
-
                   sswflx(i,j) = (1.0-covice(i,j))*sswflx(i,j) +  & !ocean
                                                   fswice(i,j)   !ice cell average
                   surflx(i,j) = (1.0-covice(i,j))*surflx(i,j) +  & !ocean
@@ -79,7 +78,7 @@
             endif !ip
           enddo !i
         enddo !j
-!$OMP END PARALLEL DO
+!$OMP   END PARALLEL DO
       elseif (iceflg.ne.0) then
           ! switch off the sssflx under sea ice
           if (sss_underice==.false.) then
@@ -99,8 +98,9 @@
           endif
           if ( cpl_swflx  .and. cpl_lwmdnflx .and. cpl_lwmupflx &
                           .and. cpl_precip   .and. cesmbeta ) then
-! ---     allow for sea ice
-!$OMP PARALLEL DO PRIVATE(j,i)
+! ---       allow for sea ice
+!$OMP       PARALLEL DO PRIVATE(j,i) &
+!$OMP                SCHEDULE(STATIC,jblk)
             do j=1,jj
                do i=1,ii
                   if (SEA_P) then
@@ -115,9 +115,10 @@
                   endif
                enddo !i
             enddo
-!$OMP END PARALLEL DO
+!$OMP       END PARALLEL DO
           else
-!$OMP PARALLEL DO PRIVATE(j,i)
+!$OMP       PARALLEL DO PRIVATE(j,i) &
+!$OMP                SCHEDULE(STATIC,jblk)
             do j=1,jj
                do i=1,ii
                  if (SEA_P) then
@@ -134,12 +135,13 @@
                   util1(i,j) = surflx(i,j)*scp2(i,j)
                   util2(i,j) = wtrflx(i,j)*scp2(i,j)
                   endif
-             enddo !i
-           enddo !j
-!$OMP END PARALLEL DO
+              enddo !i
+            enddo !j
+!$OMP       END PARALLEL DO
           endif ! .not. cpl
       else !no sea ice
-!$OMP PARALLEL DO PRIVATE(j,i)
+!$OMP   PARALLEL DO PRIVATE(j,i) &
+!$OMP            SCHEDULE(STATIC,jblk)
         do j=1,jj
           do i=1,ii
             if (SEA_P) then  !sswflx, surflx and sstflx unchanged
@@ -150,10 +152,42 @@
             endif !ip
           enddo !i
         enddo !j
-!$OMP END PARALLEL DO
+!$OMP   END PARALLEL DO
       endif !ishlf:iceflg
 !
-      if     (epmass .and. empbal.eq.1) then
+      if     (epmass.eq.2) then
+!
+! ---   balance rivflx, via a region-wide offset:
+!
+!$OMP   PARALLEL DO PRIVATE(j,i) &
+!$OMP            SCHEDULE(STATIC,jblk)
+        do j=1,jj
+          do i=1,ii
+            if (SEA_P) then
+              util3(i,j) = rivflx(i,j)*scp2(i,j)
+            endif
+          enddo !i
+        enddo !j
+        call xcsum(d2, util3,ipa)
+        d2 = d2/area
+        q  = -d2
+!$OMP   PARALLEL DO PRIVATE(j,i) &
+!$OMP            SCHEDULE(STATIC,jblk)
+        do j=1,jj
+          do i=1,ii
+            if (SEA_P) then
+              rivflx(i,j) = rivflx(i,j) + q
+            endif
+          enddo !i
+        enddo !j
+        if     (ldebug_empbal .and. &
+                mnproc.eq.1 .and. mod(nstep,100).le.1) then
+          write (lp,'(i9,a,1pe12.5)')  &
+           nstep,' offset rivflx by ',q
+        endif !master
+      endif
+!
+      if     (epmass.eq.1 .and. empbal.eq.1) then
 !
 ! ---   balance wtrflx to emptgt, via a region-wide offset:
 !
@@ -177,16 +211,23 @@
              nstep,' offset wtrflx by ',q
           endif !master
         endif !not already balanced
-      elseif (.not.epmass .and. empbal.eq.1) then
+      elseif (epmass.ne.1 .and. empbal.eq.1) then
 !
 ! ---   balance wtrflx to emptgt, via a region-wide offset:
 ! ---   virtual salt flux case, balance sss*wtrflx
 !
+!$OMP   PARALLEL DO PRIVATE(j,i) &
+!$OMP            SCHEDULE(STATIC,jblk)
         do j=1,jj
           do i=1,ii
             if (SEA_P) then
-              util3(i,j) = wtrflx(i,j)*saln(i,j,1,n)*scp2(i,j)
-              util4(i,j) =             saln(i,j,1,n)*scp2(i,j)
+              if     (epmass.eq.0) then
+                util3(i,j) = wtrflx(i,j)*saln(i,j,1,n)*scp2(i,j)
+              else !river only as mass exchange
+                util3(i,j) = (wtrflx(i,j)-rivflx(i,j))* &
+                             saln(i,j,1,n)*scp2(i,j)
+              endif
+              util4(i,j) = saln(i,j,1,n)*scp2(i,j)
             endif
           enddo !i
         enddo !j
@@ -211,13 +252,15 @@
              nstep,' offset wtrflx by ',q
           endif !master
         endif !not already balanced
-      elseif (epmass .and. empbal.eq.2) then
+      elseif (epmass.eq.1 .and. empbal.eq.2) then
 !
 ! ---   balance wtrflx to emptgt, by scaling down +ve or -ve anomalies
 !
         call xcsum(d2, util2,ipa)  !total
         d2 = d2/area               !basin-wide average
         if     (d2.ne.emptgt) then  !not balanced at emptgt
+!$OMP     PARALLEL DO PRIVATE(j,i) &
+!$OMP              SCHEDULE(STATIC,jblk)
           do j=1,jj
             do i=1,ii
               if (SEA_P) then
@@ -270,18 +313,25 @@
             endif !master
           endif !reduce -ve:reduce +ve
         endif !not already balanced
-      elseif (.not.epmass .and. empbal.eq.2) then
+      elseif (epmass.ne.1 .and. empbal.eq.2) then
 !
 ! ---   balance wtrflx to emptgt, by scaling down +ve or -ve anomalies
 ! ---   virtual salt flux case, balance sss*wtrflx
 !
+!$OMP   PARALLEL DO PRIVATE(j,i) &
+!$OMP            SCHEDULE(STATIC,jblk)
         do j=1,jj
           do i=1,ii
             if (SEA_P) then
-              util2(i,j) =     wtrflx(i,j)*saln(i,j,1,n)*scp2(i,j)
-              util3(i,j) = max(wtrflx(i,j)-emptgt,0.0)* &
-                                           saln(i,j,1,n)*scp2(i,j)
-              util4(i,j) =                 saln(i,j,1,n)*scp2(i,j)
+              if     (epmass.eq.0) then
+                util5(i,j) = wtrflx(i,j)
+              else !river only as mass exchange
+                util5(i,j) = wtrflx(i,j)-rivflx(i,j)
+              endif
+              util2(i,j) =     util5(i,j)*saln(i,j,1,n)*scp2(i,j)
+              util3(i,j) = max(util5(i,j)-emptgt,0.0)* &
+                                          saln(i,j,1,n)*scp2(i,j)
+              util4(i,j) =                saln(i,j,1,n)*scp2(i,j)
             endif
           enddo !i
         enddo !j
@@ -299,8 +349,8 @@
           do j=1,jj
             do i=1,ii
               if (SEA_P) then
-                if     (wtrflx(i,j).lt.emptgt) then
-                  wtrflx(i,j) = emptgt + q*(wtrflx(i,j)-emptgt)
+                if     (util5(i,j).lt.emptgt) then
+                  wtrflx(i,j) = emptgt + q*(util5(i,j)-emptgt)
                 endif
                 util2(i,j) = wtrflx(i,j)*scp2(i,j)
               endif
@@ -319,8 +369,8 @@
           do j=1,jj
             do i=1,ii
               if (SEA_P) then
-                if     (wtrflx(i,j).gt.emptgt) then
-                  wtrflx(i,j) = emptgt + q*(wtrflx(i,j)-emptgt)
+                if     (util5(i,j).gt.emptgt) then
+                  wtrflx(i,j) = emptgt + q*(util5(i,j)-emptgt)
                 endif
                 util2(i,j) = wtrflx(i,j)*scp2(i,j)
               endif
@@ -333,13 +383,13 @@
           endif !master
         endif !reduce -ve:reduce +ve
       endif !empbal
-
+!
 !!Alex New calculation of epmass, with E-P applied to the top layer
 !!AJW  Modified new epmass calculation to use actual dp rather than h
 !!AJW  updates pbavg, dp and S.1
 !!AJW  When E-P>0 and layer 1 is thin, some may get merged deeper
 !
-      if     (epmass) then  !requires btrlfr=.true., see blkdat.F
+      if     (epmass.gt.0) then  !requires btrlfr=.true., see blkdat.F
 !$OMP   PARALLEL DO PRIVATE(j,i,k,k1,emnp,dpemnp,dpemnp1,dplay1, &
 !$OMP                       onetanew,onetaold,pbanew,pbaold,q)
         do j=1,jj
@@ -350,7 +400,11 @@
 ! ---         This only works if pbavg and dp have just been integrated from
 ! ---         the same time, hence btrlfr=false is not allowed
 !
-              emnp   = -wtrflx(i,j)*svref  !m/s
+              if     (epmass.eq.1) then
+                emnp   = -wtrflx(i,j)*svref  !m/s
+              else !river only
+                emnp   = -rivflx(i,j)*svref  !m/s
+              endif
               pbaold = pbavg(i,j,n)
               pbanew = pbaold - emnp*delt1*onem  !emnp mass = rho0*vol
               if     (.false. .and. i.eq.itest.and.j.eq.jtest) then
@@ -361,9 +415,11 @@
                             pbaold - emaxfr*(pbot(i,j) + pbaold) )
               onetaold = 1.0 + pbaold/pbot(i,j)
               onetanew = 1.0 + pbanew/pbot(i,j)
-              !some evap may have been discarded
-              emnp        = (pbaold - pbanew)/(delt1*onem)
-              wtrflx(i,j) = -emnp/svref
+              if     (epmass.eq.1) then
+                !some evap may have been discarded
+                emnp        = (pbaold - pbanew)/(delt1*onem)
+                wtrflx(i,j) = -emnp/svref
+              endif
               if     (.false. .and. i.eq.itest.and.j.eq.jtest) then
                 write(lp,'(i9,a,1p5g12.4)') &
                   nstep,' pba,emnp = ',pbanew*qonem, &
@@ -1324,7 +1380,6 @@
                  +imp_lwdflx(i,j,1) &
                  +imp_lwuflx(i,j,1)
         elseif (natm.eq.2) then
-
           radfl=(radflx(i,j,l0)*w0+radflx(i,j,l1)*w1)
         else
           radfl=(radflx(i,j,l0)*w0+radflx(i,j,l1)*w1 &
@@ -1341,7 +1396,6 @@
           else
              radfl = radfl - sb_cst*(temp(i,j,1,n)+tzero)**4 + swfl
           endif
-
           sstflx(i,j) = 0.0
         elseif (lwflag.gt.0) then
 ! ---     over-ocean longwave correction to radfl (Qsw+Qlw).
@@ -1521,7 +1575,6 @@
         if     (empflg.lt.0) then
           evape = slat*clh*wind*(0.97*qsatur(esst)-vpmx)
         endif
-
 ! ---   Latent Heat flux (W/m2)
         if(cesmbeta .and. cpl_latflx) then
            evap=imp_latflx(i,j,1)
@@ -1789,7 +1842,7 @@
         ce_n10 = 34.6 *cd_n10_rt*1.e-3                      !L-Y eqn. 6b
         stab   = 0.5 + sign(0.5,airt-temp(i,j,1,n))
         ch_n10 = (18.0*stab+32.7*(1-stab))*cd_n10_rt*1.e-3  !L-Y eqn. 6c
-
+!
         cd10 = cd_n10  !first guess for exchange coeff's at z
         ch10 = ch_n10
         ce10 = ce_n10
@@ -1827,7 +1880,7 @@
           ce10 = ce_n10/(1.0+ce_n10*xx/cd_n10_rt) * &
                               sqrt(cd10/cd_n10)       !L-Y 10c
         end do !it_a
-
+!
 ! ---  Latent Heat flux
         slat = evaplh*rair
         if     (empflg.lt.0) then
@@ -1838,7 +1891,7 @@
         else
           evap = slat*ce10*wind*(qsatur5(temp(i,j,1,n),qrair)-vpmx)
         endif
-
+!
 ! --- Sensible Heat flux
         ssen   = cpcore*rair
         if(cesmbeta .and. cpl_sensflx) then
@@ -1846,7 +1899,7 @@
         else
           snsibl = ssen*ch10*wind*(temp(i,j,1,n)-airt)
         endif
-
+!
 ! --- Total surface fluxes
         surflx(i,j) = radfl - snsibl - evap
       elseif (flxflg.eq.3) then
@@ -2386,3 +2439,4 @@
 !> Dec. 2023 - add cesmbeta as a master switch to cpl_
 !> Jan. 2024 - evap with epmass==1 can extend below a thin enough layer 1
 !> Jan. 2024 - evap with epmass==1 may be clipped for small oneta
+!> May  2024 - added epmass=2 for river only mass exchange

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/thermf.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/thermf.F90
@@ -1314,7 +1314,7 @@
       if (SEA_P) then
       if     (flxflg.gt.0) then
 ! ---   wind = wind, or wind-ocean, speed (m/s)
-        if     (flxflg.eq.6 .and. amoflg.ne.0) then
+        if     (flxflg.eq.6 .and. ocnscl.ne.0.0) then
           wind=wndocn(i,j)  !magnitude of wind minus ocean current
         elseif(cesmbeta .and. cpl_wndspd) then
           wind=imp_wndspd(i,j,1)

--- a/hycom/hycom_ALL/hycom_2.2.72_ALL/bin/hycom_profile_hybgen.f
+++ b/hycom/hycom_ALL/hycom_2.2.72_ALL/bin/hycom_profile_hybgen.f
@@ -305,7 +305,6 @@ c --- relaxation coefficient (inverse baroclinic time steps)
       real,    parameter :: hybrlx = 1.0/8.0  !1.0/no. baroclinic time steps
 c
       logical mxlkta,thermo
-cTill      integer i,j,kk,n, lp,nstep, i0,j0,itest,jtest
       integer i,j,kk,n, lp,nstep, i0,j0,itest,jtest
       integer klist(1,1)
       real    epsil,onem,tencm,onemm,qonem,thbase


### PR DESCRIPTION
Added upstream changes and a few bugfixes
Changed epmass to integer. Check if NERSC error message is correct in blkdat.input (reviewers)

Added variable use of ocean current in (ocnscl) Default is 1.0 which will result in full relative wind (windx-ocnscl*Uocn). See mod_momtum. This should result in removal of negative wndflg and removal of amoflg as this no longer make sense. I will suggest that to the upstream. Note this is the only part which changes the md5sum (bit for bit check of restart after one day).

A conservative cfl flag criterion is added when cpp flag momtum_cfl is added. This is not tested and to not change result when false. 
Added hybthk. Default to normal when set to 0.0. A way of avoiding to thin hybrid layers. There is a bug as the pressure p(kdm) sometimes is smaller than p(kdm+1), which is unphysical as it represents a layer with negative thickness at the bottom. This seems to be a numerical issue and it is only in the order of a few mm. Solved by requiring that the difference cannot be lower than 0. Another thing to raise to upstream. This is not related to this implementation. 

I found a parenthesis missing in a cpp block that required STOKES added. This is located in mod_barotrop. I have not checked that it is correct as I dont run with this