### PR TITLE
Need to raise error if time not found in forcing file

### DIFF
--- a/pythonlibs/abfile/abfile/abfile.py
+++ b/pythonlibs/abfile/abfile/abfile.py
@@ -818,6 +818,8 @@ class ABFileForcing(ABFile) :
       """ Read field corresponding to fieldname and level from archive file"""
       elems = [ (k,v["dtime1"]) for k,v in self._fields.items() if v["field"] == field]
       dist = numpy.array([elem[1]-dtime1 for elem in elems])
+      if numpy.min(numpy.abs(dist)) > 1.0:
+          raise RuntimeError(f"cannot find matching time {dtime1} in forcing file {self.basename}, closest time dist is {dist}.")
       i =numpy.argmin(numpy.abs(dist))
       rec,dt = elems[i]
       w = self._filea.read_record(i) 
@@ -1151,6 +1153,8 @@ class ABFileRelaxZ(ABFile) :
       """ Read field corresponding to fieldname and level from archive file"""
       elems = [ (k,v["dtime1"]) for k,v in self._fields.items() if v["field"] == field]
       dist = numpy.array([elem[1]-dtime1 for elem in elems])
+      if numpy.min(numpy.abs(dist)) > 1.0:
+          raise RuntimeError(f"cannot find matching time {dtime1} in file {self.basename}, closest time dist is {dist}.")
       i =numpy.argmin(numpy.abs(dist))
       rec,dt = elems[i]
       w = self._filea.read_record(i) 


### PR DESCRIPTION
Current logic in ABFileForcing.read_field() is that the field with minimum time distance to the given dtime1 will be returned. This is problematic if requested dtime1 is outside of the available range of time indices in the forcing file, it will always return the field at the beginning (or the end). The right thing to do is set a tolerance (1 day) and if min(dist) is beyond that raise a RuntimeError warning the user that dtime1 requested is not found in the file.