### PR TITLE
Update of limitation of salinity relaxation. Replaces Hardcoded value. 

### DIFF
--- a/TP5a0.06/expt_01.0/hycom_opt
+++ b/TP5a0.06/expt_01.0/hycom_opt
@@ -1,4 +1,5 @@
 &hycom_nml
-    write_arche= .false.
-    sss_underice= .false.
+  write_arche = .false.
+  sss_underice= .false.
+  sssrmx_scalar=99.
 /

--- a/TP5a0.06/expt_02.3/hycom_opt
+++ b/TP5a0.06/expt_02.3/hycom_opt
@@ -1,5 +1,5 @@
 &hycom_nml
   write_arche = .false.
   sss_underice= .false.
+  sssrmx_scalar=99.
 /
-

--- a/bin/calc_montg1.py
+++ b/bin/calc_montg1.py
@@ -33,16 +33,17 @@ python /cluster/home/achoth/pyScripts_AO_Betzy/ValidationFreq/Alf_calc_montg1.py
 
 """
 # Get component of montgomery potential at surface that depends on pbavg
-def montg1_pb(thstar,p) :
-   kdm=thstar.shape[0]
-   #AO thref=_constants.thref
-   thref=1e-3
-   # Part that depends on pbavg :
-   montgpb=-thstar[kdm-1,:,:]*thref**2
-   for k in reversed(range(kdm-1)) :
-      # PArt that depends on pbavg (through oneta) 
-      montgpb[:,:]=montgpb[:,:]+ p[k+1,:,:]*(thstar[k+1,:,:]-thstar[k,:])*thref**2/p[kdm,:,:]
-   return montgpb
+def montg1_pb(thstar,p,pbot) :
+    kdm=thstar.shape[0]
+    #AO thref=_constants.thref
+    thref=1e-3
+    # Part that depends on pbavg :
+    montgpb=-thstar[kdm-1,:,:]*thref**2
+    for k in reversed(range(kdm-1)) :
+        # PArt that depends on pbavg (through oneta) 
+        montgpb[:,:]=montgpb[:,:]+ p[k+1,:,:]*(thstar[k+1,:,:]-thstar[k,:,:])*thref**2/pbot[:,:]
+
+    return montgpb
 
 
 # Get component of montgomery potential at surface that does not depend on pbavg
@@ -52,40 +53,47 @@ def montg1_no_pb(psikk,thkk,thstar,p) :
    thref=1e-3
    montgc=psikk+(p[kdm,:,:]*(thkk-thstar[kdm-1,:,:]))*thref**2
    for k in reversed(range(kdm-1)) :
-      montgc [:,:]=montgc [:,:]+ p[k+1,:,:]*(thstar[k+1,:,:]-thstar[k,:])*thref**2
+       montgc [:,:]=montgc [:,:]+ p[k+1,:,:]*(thstar[k+1,:,:]-thstar[k,:,:])*thref**2
    return montgc
 
-
-def approx_montg1(thstar,p,srfhgt,idm,jdm,rstr_file):
-         # estimate montg1---------------------------------------------
-         # Read input variables from lowest layer of a restart file
-         thref=1e-3
-         #psikk_file="./TP6restart.2021_041_00_0000.a"
-         psikk_file=rstr_file#[0]#[-30:]
-         logger.info("----->rstr_file :%s"%psikk_file)
-         m=re.match( "^(.*)(\.[ab])", psikk_file)
-         if m : psikk_file=m.group(1)
-         logger.info("----->rstr_file :%s"%psikk_file)
-         rfile=abfile.ABFileRestart(psikk_file,"r",idm=idm,jdm=jdm)
-         psikk=rfile.read_field("psikk",0)
-         thkk=rfile.read_field("thkk",0)
-         rfile.close()
-         #print(( "psikk.min(),psikk.max()=",psikk.min(),psikk.max())
-         #print( "thkk.min(),thkkk.max()=",thkk.min(),thkk.max()
-         #
-         #montg1pb = modeltools.hycom._montg_tools.montg1_pb(thstar,p)
-         #montg1c  = modeltools.hycom._montg_tools.montg1_no_pb(psikk,thkk,thstar,p) 
-         montg1pb = montg1_pb(thstar,p)
-         montg1c  = montg1_no_pb(psikk,thkk,thstar,p)
-         print( "montg1c.min(),montg1c.max()=",montg1c.min(),montg1c.max())
-         print( "montg1pb.min(),montg1pb.max()=",montg1pb.min(),montg1pb.max() )
-         pbavg  = (srfhgt - montg1c) / (montg1pb+thref)
-         print( "pbavg.min(),pbavg.max()=",pbavg.min(),pbavg.max() )
-         montg1 = montg1pb*pbavg + montg1c
-         logger.info("Estimated montg1 ")
-         print( " min max montg1=",montg1.min(),montg1.max() )
-         # end estimate montg1---------------------------------------------
-         return montg1
+def approx_montg1(thstar,p,srfhgt,idm,jdm,rstr_file,iversn,kdm):
+    # estimate montg1---------------------------------------------
+    # Read input variables from lowest layer of a restart file
+    thref=1e-3
+    psikk_file=rstr_file#[0]#[-30:]
+    logger.info("----->rstr_file :%s"%psikk_file)
+    m=re.match( "^(.*)(\.[ab])", psikk_file)
+    if m : psikk_file=m.group(1)
+    logger.info("----->rstr_file :%s"%psikk_file)
+    rfile=abfile.ABFileRestart(psikk_file,"r",idm=idm,jdm=jdm)
+    psikk=rfile.read_field("psikk",0)
+    thkk=rfile.read_field("thkk",0)
+    if iversn==22:
+        pbot=p[kdm,:,:]
+    elif iversn==23:
+        pbot=rfile.read_field("pbot",0)
+    else:
+        logger.info("Unknovn HYCOM version "%iversn)
+        sys.exit()
+    rfile.close()
+    pbot[pbot==0.]=numpy.nan
+    #print(( "psikk.min(),psikk.max()=",psikk.min(),psikk.max())
+    #print( "thkk.min(),thkkk.max()=",thkk.min(),thkk.max()
+    #
+    #montg1pb = modeltools.hycom._montg_tools.montg1_pb(thstar,p)
+    #montg1c  = modeltools.hycom._montg_tools.montg1_no_pb(psikk,thkk,thstar,p) 
+    montg1pb = montg1_pb(thstar,p,pbot)
+    montg1c  = montg1_no_pb(psikk,thkk,thstar,p)
+    print( "montg1c.min(),montg1c.max()=",montg1c.min(),montg1c.max())
+    print( "montg1pb.min(),montg1pb.max()=",montg1pb.min(),montg1pb.max() )
+    pbavg  = (srfhgt - montg1c) / (montg1pb+thref)
+    print( "pbavg.min(),pbavg.max()=",pbavg.min(),pbavg.max() )
+    print( "montg1pb*pbavg.min(),montg1pb*pbavg.max()=",(montg1pb*pbavg).min(),(montg1pb*pbavg).max())
+    montg1 = montg1pb*pbavg + montg1c
+    logger.info("Estimated montg1 ")
+    print( " min max montg1=",montg1.min(),montg1.max() )
+    # end estimate montg1---------------------------------------------
+    return montg1
 
 
 
@@ -168,7 +176,7 @@ def main(archv_files,restart_file,out_path) :
       ###AA regr = open("montg_regress_tide.pckl",'rb')
       ###AA a,b,nemomeandt = pickle.load(regr)
       ###AA tide_montg1 = (nemo_srfhgt - nemomeandt) * a + b
-      estimated_montg1=approx_montg1(thstar,p,nemo_srfhgt,idm,jdm,restart_file)
+      estimated_montg1=approx_montg1(thstar,p,nemo_srfhgt,idm,jdm,restart_file,iversn,kdm)
       #---#
       #read all keys and write updated version
       for keys in sorted(arcfile_in.fields.keys()) :

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/forfun.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/forfun.F90
@@ -1770,6 +1770,9 @@
 #ifdef _FABM_
       use mod_hycom_fabm
 #endif
+#ifdef NERSC_HYCOM_CICE
+     use mod_NERSCnml, only : sssrmx_scalar
+#endif
       implicit none
 !
 ! --- initialize input of thermal/tracer relaxation forcing fields
@@ -1939,10 +1942,10 @@
         call zaiocl(915)
       else
         if     (mnproc.eq.1) then
-        write (lp,*) 'No sss relaxation limiter.'
+        write (lp,*) 'sss relaxation limiter set to sssrmx_scalar.'
         endif !1st tile
         !sssrmx(:,:) = 99.9  !needed for thermf, set to no limit
-        sssrmx(:,:) = 1.0  !set one psu limit
+        sssrmx(:,:) = sssrmx_scalar  !set according to NERSC namelist
       endif
 !
       if     (relax) then  ! boundary thermal relaxation

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/forfun.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/forfun.F90
@@ -1942,10 +1942,14 @@
         call zaiocl(915)
       else
         if     (mnproc.eq.1) then
-        write (lp,*) 'sss relaxation limiter set to sssrmx_scalar.'
+           write (lp,*) 'sss relaxation limiter set to sssrmx_scalar.'
         endif !1st tile
         !sssrmx(:,:) = 99.9  !needed for thermf, set to no limit
         sssrmx(:,:) = sssrmx_scalar  !set according to NERSC namelist
+        if     (mnproc.eq.1) then
+           write (lp,'(a45,f10.4)') 'sss relaxation limiter set to sssrmx_scalar.:', sssrmx_scalar
+        endif !1st tile
+
       endif
 !
       if     (relax) then  ! boundary thermal relaxation

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_NERSCnml.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_NERSCnml.F90
@@ -30,11 +30,11 @@ module mod_NERSCnml
     sssrmx_scalar   = 99.0
 
     ! read namelist
-    open (funi, file='../hycom_opt', status='old',iostat=nml_err)
+    open (funi, file='./hycom_opt', status='old',iostat=nml_err)
     if (nml_err .ne. 0) then
       if  (mnproc.eq.1) then
         write (lp,'(a)') &
-          'NERSC HYCOM ERROR: WARNING: hycom_nml namelist not read from file: ../hycom_opt'
+          'NERSC HYCOM ERROR: WARNING: hycom_nml namelist not read from file: ./hycom_opt'
         call flush(lp)
       endif
     endif
@@ -52,10 +52,9 @@ module mod_NERSCnml
     end do
     close(funi)
     if (mnproc.eq.1) then
-      write (lp,*)'NERSC HYCOM: Reading hycom_nml from: ../hycom_opt'
+      write (lp,*)'NERSC HYCOM: Reading hycom_nml from: ./hycom_opt'
       write (lp,*)'NERSC HYCOM: Write arche    = ',write_arche
-      write (lp,*)'             sss_underice   = ',sss_underice
-      write (lp,*)' NERSC HYCOM: sssrmx_scalar = ',sssrmx_scalar
+      write (lp,*)'NERSC HYCOM: sss_underice   = ',sss_underice
     endif !1st tile
     call xcsync(flush_lp)
 

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_NERSCnml.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_NERSCnml.F90
@@ -6,10 +6,13 @@ module mod_NERSCnml
   implicit none
   private
  
+  real, save, public   :: &
+    sssrmx_scalar       ! Limit for salinity relax Only used if
 
   logical,save, public :: &
     write_arche, &      ! print arche files or not
-    sss_underice     ! relaxtion under ice (false if no) 
+    sss_underice        ! relaxtion under ice (false if no) 
+
   public NERSC_init
 
   contains
@@ -20,10 +23,12 @@ module mod_NERSCnml
     implicit none
     integer (4), parameter :: funi=503
     integer (4) :: nml_err
-    namelist /hycom_nml/ write_arche,sss_underice
+    namelist /hycom_nml/ write_arche,sss_underice, sssrmx_scalar
     !default values
     write_arche     = .false.
     sss_underice    = .false.
+    sssrmx_scalar   = 99.0
+
     ! read namelist
     open (funi, file='../hycom_opt', status='old',iostat=nml_err)
     if (nml_err .ne. 0) then
@@ -38,7 +43,7 @@ module mod_NERSCnml
       if (nml_err > 0) then
         if (mnproc.eq.1) then
           write (lp,'(a)') &
-          'NERSC HYCOM ERROR: Can not read namelist: ../hycom_opt'
+          'NERSC HYCOM ERROR: Can not read namelist: hycom_opt'
           call flush(lp)
           call xcstop('(NERSC_nml)')
           stop '(NERSC_nml)'
@@ -50,6 +55,7 @@ module mod_NERSCnml
       write (lp,*)'NERSC HYCOM: Reading hycom_nml from: ../hycom_opt'
       write (lp,*)'NERSC HYCOM: Write arche    = ',write_arche
       write (lp,*)'             sss_underice   = ',sss_underice
+      write (lp,*)' NERSC HYCOM: sssrmx_scalar = ',sssrmx_scalar
     endif !1st tile
     call xcsync(flush_lp)
 

--- a/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/forfun.F
+++ b/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/forfun.F
@@ -1479,6 +1479,9 @@ c
 #ifdef _FABM_
       use mod_hycom_fabm
 #endif
+#ifdef NERSC_HYCOM_CICE
+     use mod_NERSCnml, only : sssrmx_scalar
+#endif
       implicit none
 c
 c --- initialize input of thermal/tracer relaxation forcing fields
@@ -1574,9 +1577,10 @@ c
         call zaiocl(915)
       else
         if     (mnproc.eq.1) then
-        write (lp,*) 'sss relaxation is limited (less than 0.5).'
+        write (lp,*) 'sss relaxation limiter set to sssrmx_scalar.'
         endif !1st tile
-        sssrmx(:,:) = 0.5  !needed for thermf, set to a limit of 0.5 psu
+        !sssrmx(:,:) = 99.9  !needed for thermf, set to no limit
+        sssrmx(:,:) = sssrmx_scalar  !set according to NERSC namelist
       endif
 c
       if     (relax) then  ! boundary thermal relaxation

--- a/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_NERSCnml.F90
+++ b/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_NERSCnml.F90
@@ -6,6 +6,9 @@ module mod_NERSCnml
   implicit none
   private
  
+  real, save, public   :: &
+    sssrmx_scalar       ! Limit for salinity relax Only used if
+
   logical,save, public :: &
     write_arche, &      ! print arche files or not
     sss_underice        ! relaxtion under ice (false if no) 
@@ -20,10 +23,12 @@ module mod_NERSCnml
     implicit none
     integer (4), parameter :: funi=503
     integer (4) :: nml_err
-    namelist /hycom_nml/ write_arche,sss_underice
+    namelist /hycom_nml/ write_arche,sss_underice, sssrmx_scalar
     !default values
     write_arche     = .false.
     sss_underice    = .false.
+    sssrmx_scalar   = 99.0
+
     ! read namelist
     open (funi, file='../hycom_opt', status='old',iostat=nml_err)
     if (nml_err .ne. 0) then

--- a/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_NERSCnml.F90
+++ b/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_NERSCnml.F90
@@ -34,7 +34,7 @@ module mod_NERSCnml
     if (nml_err .ne. 0) then
       if  (mnproc.eq.1) then
         write (lp,'(a)') &
-          'NERSC HYCOM ERROR: WARNING: hycom_nml namelist not read from file: ../hycom_opt'
+          'NERSC HYCOM ERROR: WARNING: hycom_nml namelist not read from file: ./hycom_opt'
         call flush(lp)
       endif
     endif
@@ -52,9 +52,9 @@ module mod_NERSCnml
     end do
     close(funi)
     if (mnproc.eq.1) then
-      write (lp,*)'NERSC HYCOM: Reading hycom_nml from: ../hycom_opt'
+      write (lp,*)'NERSC HYCOM: Reading hycom_nml from: ./hycom_opt'
       write (lp,*)'NERSC HYCOM: Write arche    = ',write_arche
-      write (lp,*)'      HYCOM: sss_underice   = ',sss_underice
+      write (lp,*)'NERSC HYCOM: sss_underice   = ',sss_underice
     endif !1st tile
     call xcsync(flush_lp)
 


### PR DESCRIPTION
Added namelist parameter sssrmx_scalar. Set to limiter.
hycom_opt must be in SCRATCH when running in order to be read.
Tested for v2.3 but also implemented in v2.2.
