### PR TITLE
Renamed rmu_nest to rmu and ports.nest to ports.input as needed in HYCOM

### DIFF
--- a/bin/calc_montg1.py
+++ b/bin/calc_montg1.py
@@ -73,9 +73,10 @@ def approx_montg1(thstar,p,srfhgt,idm,jdm,rstr_file,iversn,kdm):
     elif iversn==23:
         pbot=rfile.read_field("pbot",0)
     else:
-        logger.info("Unknovn HYCOM version "%iversn)
+        logger.info("Unknovn HYCOM version %i"%iversn)
         sys.exit()
     rfile.close()
+    logger.info("HYCOM version %i"%iversn)
     pbot[pbot==0.]=numpy.nan
     #print(( "psikk.min(),psikk.max()=",psikk.min(),psikk.max())
     #print( "thkk.min(),thkkk.max()=",thkk.min(),thkk.max()

--- a/bin/expt_preprocess.sh
+++ b/bin/expt_preprocess.sh
@@ -552,29 +552,29 @@ elif [ $tmp -eq 1 -a $LBFLAG -eq 1 ] ; then
    cp $P/ports.input . || tellerror "Could not get port file ${P}/ports.input for port flow"
 elif [ $tmp -eq 1 -a $LBFLAG -eq 2 ] ; then
    # Nest flow - use file in  experiment dir if present. Otherwise look in nest dir
-   if [ -f $P/ports.nest ] ; then
-      echo "Using file $P/ports.nest for nesting: $P/ports.nest -> ./ports.input"
-      cp $P/ports.nest ports.input       || tellerror "Could not get port file ${P}/ports.nest for nest flow"
-   elif [ -f $nestdir/ports.nest ] ; then
-      echo "Using file $nestdir/ports.nest for nesting: $P/ports.nest -> ./ports.input"
-      cp $nestdir/ports.nest ports.input || tellerror "Could not get port file ${nestdir}/ports.nest for nest flow"
+   if [ -f $P/ports.input ] ; then
+      echo "Using file $P/ports.input for nesting: $P/ports.input -> ./ports.input"
+      cp $P/ports.input ports.input       || tellerror "Could not get port file ${P}/ports.input for nest flow"
+   elif [ -f $nestdir/ports.input ] ; then
+      echo "Using file $nestdir/ports.input for nesting: $P/ports.input -> ./ports.input"
+      cp $nestdir/ports.input ports.input || tellerror "Could not get port file ${nestdir}/ports.input for nest flow"
    else 
-      tellerror "Could not get port file ports.nest in $P or  ${nestdir} for nest flow"
+      tellerror "Could not get port file ports.input in $P or  ${nestdir} for nest flow"
    fi
 fi
 
 # Need nest rmu in this case:
 if [ $tmp2 -eq 1  ] ; then
    # Nest relaxation - use file in  experiment dir if present. Otherwise look in nest dir
-#   if [ -f $P/rmu_nest.a -a -f $P/rmu_nest.a ] ; then
-#      echo "Using file $P/rmu_nest.[ab] for nesting relaxation: $P/rmu_nest.[ab] -> ./rmu.[ab]"
-#      cp $P/rmu_nest.a rmu.a       || tellerror "Could not get port file ${P}/rmu_nest.a for nest relax"
-#      cp $P/rmu_nest.b rmu.b       || tellerror "Could not get port file ${P}/rmu_nest.b for nest relax"
-#   elif [ -f $nestdir/rmu_nest.a -a -f $nestdir/rmu_nest.a ] ; then
-#      echo "Using file $nestdir/rmu_nest.[ab] for nesting: $nestdir/rmu_nest.[ab] -> ./rmu.[ab]"
-#      cp $nestdir/rmu_nest.a rmu.a       || tellerror "Could not get port file ${nestdir}/rmu_nest.a for nest relax"
-#      cp $nestdir/rmu_nest.b rmu.b       || tellerror "Could not get port file ${nestdir}/rmu_nest.b for nest relax"
-#   fi
+   if [ -f $P/rmu.a -a -f $P/rmu.a ] ; then
+      echo "Using file $P/rmu.[ab] for nesting relaxation: $P/rmu.[ab] -> ./rmu.[ab]"
+      cp $P/rmu.a rmu.a       || tellerror "Could not get port file ${P}/rmu.a for nest relax"
+      cp $P/rmu.b rmu.b       || tellerror "Could not get port file ${P}/rmu.b for nest relax"
+   elif [ -f $nestdir/rmu.a -a -f $nestdir/rmu.a ] ; then
+      echo "Using file $nestdir/rmu.[ab] for nesting: $nestdir/rmu.[ab] -> ./rmu.[ab]"
+      cp $nestdir/rmu.a rmu.a       || tellerror "Could not get port file ${nestdir}/rmu.a for nest relax"
+      cp $nestdir/rmu.b rmu.b       || tellerror "Could not get port file ${nestdir}/rmu.b for nest relax"
+   fi
   if [ -f $nestdir/rmu.a -a -f $nestdir/rmu.b ] ; then
       echo "Using file $nestdir/rmu.[ab] for nesting"
    else 

--- a/bin/nest_rmu_linear.csh
+++ b/bin/nest_rmu_linear.csh
@@ -1,10 +1,10 @@
 #!/bin/csh
-# Create rmu_nest files with a varying e-folding time
-# For the coordinates (if,il,jf,jl) consult ports.nest
+# Create rmu files with a varying e-folding time
+# For the coordinates (if,il,jf,jl) consult ports.input
 # Every relaxation zone can be split into multiple boxes
 # IF,IL,JF,JL - ARRAY BOX WHERE EFOLD RELAXATION IS APPLIED
 # The cuurent script is configured for TP5:
-#ports.nest for TP5: 
+#ports.input for TP5: 
 #    2  'nports' = Number of ports 
 #    1  'kdport' = port orientation (1=N, 2=S, 3=E, 4=W)
 #   17  'ifport' = first i-index

--- a/bin/nest_setup_ports.sh
+++ b/bin/nest_setup_ports.sh
@@ -63,8 +63,8 @@ touch  ports.input.tmp && rm ports.input.tmp
 echo ${PORT_ROUTINE}  depth_${R}_${T} $width $efold
 ${PORT_ROUTINE}  depth_${R}_${T} $width $efold
 if [ $? -eq 0 ] ; then
-   cp  ports.input.tmp $TARGETDIR/ports.nest
-   echo "Created ports file $TARGETDIR/ports.nest"
+   cp  ports.input.tmp $TARGETDIR/ports.input
+   echo "Created ports file $TARGETDIR/ports.input"
    cp  rmu.a $TARGETDIR/rmu.a
    cp  rmu.b $TARGETDIR/rmu.b
 else 

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/forfun.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/forfun.F90
@@ -1771,7 +1771,7 @@
       use mod_hycom_fabm
 #endif
 #ifdef NERSC_HYCOM_CICE
-     use mod_NERSCnml, only : sssrmx_scalar
+      use mod_NERSCnml, only : sssrmx_scalar
 #endif
       implicit none
 !


### PR DESCRIPTION
This renames rmu_nest -> rmu and ports.nest -> ports.input to follow the HYCOM naming.

In addition a small log bug is removed from calc_montg1.py

Note that if rmu_nest and ports.input has already been calculated then they need to be renamed. 