### PR TITLE
Issue high frequency river

### DIFF
--- a/bin/expt_preprocess.sh
+++ b/bin/expt_preprocess.sh
@@ -407,7 +407,6 @@ if [ $PRIVER -eq 1 ] ; then
    fi
 fi
 
-#
 if [ "$HRIVER" = ".true." ]; then
   echo "Note: PRIVER must be 0 for highfq_river=true " 
   echo "highfq_river=true: **Setting up high frequency river forcing  from hycom_opt highfq_river"
@@ -535,11 +534,11 @@ tmp2=$(echo $NESTFQ'!='0.0 | bc -l)
 if [ $tmp -eq 1 -o $tmp2 -eq 1 ] ; then
    nestdir=$BASEDIR/nest/$E
    echo "Nesting input from $nestdir"
-   ls nest
+   ls sest
    if [ -d $nestdir ]  ; then
       [ -e nest ] && rm nest
       ln -s $nestdir nest
-   else 
+   else
       tellerror "Nesting dir $nest does not exist"
    fi
 fi
@@ -608,11 +607,6 @@ fi
 #if [ "$tideflag" == "T" ] ; then
 #   ${pget} ${BASEDIR}/tides_nersc/$E/${tidechoice}obc_elev.dat . || tellerror "Could not get tidal data ${tidechoice}obc_elev.dat "
 #fi
-   
-
-
-
-echo
 
 #
 # --- move old restart files to KEEP, typically from batch system rerun.

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/forfun.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/forfun.F90
@@ -202,6 +202,8 @@
 ! --- units of spchum are kg/k
 ! --- units of mslprs are Pa     (anomaly, offset from total by prsbas)
 ! --- units of precip are m/s    (positive into ocean)
+! --- units of rivers are m/s    (positive into ocean)
+
 ! --- units of radflx are w/m^2  (positive into ocean)
 ! --- units of swflx  are w/m^2  (positive into ocean)
 ! --- units of offlux are w/m^2  (positive into ocean)
@@ -657,7 +659,8 @@
 ! --- units of spchum are kg/k
 ! --- units of mslprs are Pa     (anomaly, offset from total by prsbas)
 ! --- units of precip are m/s    (positive into ocean)
-! --- units of riverh are m/s    (positive into ocean)
+! --- units of rivers are m/s    (positive into ocean)
+
 ! --- units of radflx are w/m^2  (positive into ocean)
 ! --- units of swflx  are w/m^2  (positive into ocean)
 ! --- units of offlux are w/m^2  (positive into ocean)
@@ -962,7 +965,6 @@
 #if defined(NERSC_HYCOM_CICE)
 !ALF  --- read high frequency rivers----
         if (highfq_river) then
-           !write (lp,*) 'Reading  highfq_river   = ',highfq_river
           call zaiopf(flnmfor(1:lgth)//'forcing.riverh.a', 'old', 918)
           if     (mnproc.eq.1) then  ! .b file from 1st tile only
           open (unit=uoff+918,file=flnmfor(1:lgth)//'forcing.riverh.b',
@@ -3021,6 +3023,8 @@
 !ALFA  --- read high frequency rivers----
       if (highfq_river) then
         call rdpall1(rivers,dtime(918),918,mod(icall,3).eq.1)
+      else
+        dtime(918) = dtime(905)
       endif
 !End  --- read high frequency rivers----
 #endif
@@ -3260,6 +3264,9 @@
       use mod_xc         ! HYCOM communication interface
       use mod_cb_arrays  ! HYCOM saved arrays
       use mod_za         ! HYCOM I/O interface
+#if defined(NERSC_HYCOM_CICE)
+      use mod_NERSCnml, only : highfq_river 
+#endif
       implicit none
 !
       integer lslot,mnth
@@ -3493,6 +3500,9 @@
 #if defined(NERSC_HYCOM_CICE)
 !KAL
           swflxdwn(i,j,lslot) = 0.0
+          if (highfq_river) then
+            rivers(i,j,lslot) = 0.0
+          endif
 #endif
           enddo
         enddo
@@ -5165,3 +5175,4 @@
 !> Mar  2021 - skip tracers in nest archive files
 !> Apr  2021 - update the halo of rmu
 !> Nov  2022 - skip oneta in nest archive files
+!> Jun  2025 - Introduce the high frequency river inflow

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/forfun.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/forfun.F90
@@ -967,8 +967,8 @@
         if (highfq_river) then
           call zaiopf(flnmfor(1:lgth)//'forcing.riverh.a', 'old', 918)
           if     (mnproc.eq.1) then  ! .b file from 1st tile only
-          open (unit=uoff+918,file=flnmfor(1:lgth)//'forcing.riverh.b',
-     &       status='old', action='read')
+          open (unit=uoff+918,file=flnmfor(1:lgth)//'forcing.riverh.b', &
+             status='old', action='read')
           read (uoff+918,'(a79)') preambl
           endif !1st tile
           call preambl_print(preambl)

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_NERSCnml.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_NERSCnml.F90
@@ -63,8 +63,8 @@ module mod_NERSCnml
     call flush(lp)
     if (priver .and. highfq_river) then
         if (mnproc.eq.1) then
-           write(lp,*)
-   &       'error - priver must be .false. for highfq_river=.true.'
+           write(lp,*) &
+           'error - priver must be .false. for highfq_river=.true.'
            call flush(lp)
         endif !1st tile
         call xcstop('(NERSC_nml)')

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_NERSCnml.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_NERSCnml.F90
@@ -2,7 +2,7 @@ module mod_NERSCnml
 ! allow for namelist inputs in order to 
   use mod_xc
   use mod_za  ! HYCOM I/O interface
-
+  use mod_cb_arrays, only: priver
   implicit none
   private
  
@@ -39,6 +39,7 @@ module mod_NERSCnml
           'NERSC HYCOM ERROR: WARNING: hycom_nml namelist not read from file: ./hycom_opt'
         call flush(lp)
       endif
+      call xcstop('(NERSC_nml)')
     endif
     do while (nml_err == 0)
       read(funi, nml=hycom_nml,iostat=nml_err)
@@ -47,20 +48,29 @@ module mod_NERSCnml
           write (lp,'(a)') &
           'NERSC HYCOM ERROR: Can not read namelist: hycom_opt'
           call flush(lp)
-          call xcstop('(NERSC_nml)')
-          stop '(NERSC_nml)'
         endif
+        call xcstop('(NERSC_nml)')
       endif
     end do
     close(funi)
     if (mnproc.eq.1) then
       write (lp,*)'NERSC HYCOM: Reading hycom_nml from: ./hycom_opt'
       write (lp,*)'NERSC HYCOM: Write arche    = ',write_arche
-      write (lp,*)'      HYCOM: sss_underice   = ',sss_underice
-      write (lp,*)'      HYCOM: highfq_river   = ',highfq_river
+      write (lp,*)'NERSC HYCOM: sss_underice   = ',sss_underice
+      write (lp,*)'NERSC HYCOM: sssrmx_scalar  = ',sssrmx_scalar
+      write (lp,*)'NERSC HYCOM: highfq_river   = ',highfq_river
     endif !1st tile
+    call flush(lp)
+    if (priver .and. highfq_river) then
+        if (mnproc.eq.1) then
+           write(lp,*)
+   &       'error - priver must be .false. for highfq_river=.true.'
+           call flush(lp)
+        endif !1st tile
+        call xcstop('(NERSC_nml)')
+        stop '(NERSC_nml)'
+    endif
     call xcsync(flush_lp)
-
   end subroutine NERSC_init
 
   !---------------------------------------------------------------------+

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_cb_arrays.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_cb_arrays.F90
@@ -1592,7 +1592,7 @@
              rmunvu(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
              rmunvv(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
              rmutra(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
-               rmus(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) ) 
+               rmus(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) )
 #if defined(_FABM_)
       call mem_stat_add( 8*(idm+2*nbdy)*(jdm+2*nbdy) )
 #else

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_hycom.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_hycom.F90
@@ -1768,15 +1768,7 @@
       call blkdat(linit)  !must call before zaiost
 #if defined(NERSC_HYCOM_CICE)
       call NERSC_init
-      if     (priver .and. highfq_river) then
-        if (mnproc.eq.1) then
-          write(lp,*)
-     &    'error - priver must be .false. for highfq_river=.true.'
-          call flush(lp)
-        endif !1st tile
-        call xcstop('(blkdat)')
-               stop '(blkdat)'
-      endif
+
 #endif
 !
 ! --- initialize array i/o.
@@ -1966,7 +1958,7 @@
       elseif (jerlv0.eq.-1) then
         call forfunc  !  annual/monthly chl
       endif
-#if defined(NERSC_HYCOM_CICE)     
+#if defined(NERSC_HYCOM_CICE)
       if (highfq_river) then
         if (mnproc.eq.1) then
           write(lp,*)
@@ -2474,10 +2466,10 @@
            call rdrivr(mr3,lr3)
          endif
 #else
-        call rdrivr(mr0,lr0)
-        call rdrivr(mr1,lr1)
-        call rdrivr(mr2,lr2)
-        call rdrivr(mr3,lr3)
+           call rdrivr(mr0,lr0)
+           call rdrivr(mr1,lr1)
+           call rdrivr(mr2,lr2)
+           call rdrivr(mr3,lr3)
 #endif /* USE_NUOPC_CESMBETA:else */
       endif
 !

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_hycom.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_hycom.F90
@@ -1961,8 +1961,8 @@
 #if defined(NERSC_HYCOM_CICE)
       if (highfq_river) then
         if (mnproc.eq.1) then
-          write(lp,*)
-     &    '--- Skipping the monthly river inflow----'
+          write(lp,*) &
+         '--- Skipping the monthly river inflow----'
           call flush(lp)
         endif !1st tile
       else

--- a/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/Makefile
+++ b/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/Makefile
@@ -180,7 +180,7 @@ mod_xc.o: mod_xc.F  mod_dimensions.o mod_xc_sm.h mod_xc_mp.h
 mod_za.o: mod_za.F  mod_xc.o         mod_za_sm.h mod_za_mp.h mod_za_mp1.h mod_za_zt.h
 
 mod_OICPL.o: mod_OICPL.F
-mod_NERSCnml.o: mod_NERSCnml.F90
+mod_NERSCnml.o: mod_NERSCnml.F90 mod_cb_arrays.o
 
 
 mod_netcdf_util.o: \

--- a/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/dimensions.h
+++ b/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/dimensions.h
@@ -43,7 +43,7 @@ c --- mxtrcr= maximum number of tracers
 c
 c --- natm  = number of saved atmospheric fields
       integer    natm
-      parameter (natm=4)      ! must be 2 (high freq.) or 4 (monthly) 
+      parameter (natm=4)      ! must be 2 (high freq.) or 4 (monthly)
 c                             ! set in blkdat.F based on yrflag
 c
 c ---   END OF REGION AND TILING SPECIFIC PARAMETERS

--- a/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/forfun.F
+++ b/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/forfun.F
@@ -81,7 +81,7 @@ c --- units of seatmp are degC
 c --- units of vapmix are kg/k
 c --- units of mslprs are Pa     (anomaly, offset from total by prsbas)
 c --- units of precip are m/s    (positive into ocean)
-c --- units of riverh are m/s    (positive into ocean)
+c --- units of river  are m/s    (positive into ocean)
 c --- units of radflx are w/m^2  (positive into ocean)
 c --- units of swflx  are w/m^2  (positive into ocean)
 c --- units of offlux are w/m^2  (positive into ocean)
@@ -517,7 +517,7 @@ c --- units of seatmp are degC
 c --- units of vapmix are kg/kg
 c --- units of mslprs are Pa     (anomaly, offset from total by prsbas)
 c --- units of precip are m/s    (positive into ocean)
-c --- units of riverh are m/s    (positive into ocean)
+c --- units of river  are m/s    (positive into ocean)
 c --- units of radflx are w/m^2  (positive into ocean)
 c --- units of swflx  are w/m^2  (positive into ocean)
 c --- units of offlux are w/m^2  (positive into ocean)
@@ -1612,7 +1612,6 @@ c
         if     (mnproc.eq.1) then
         write (lp,*) 'sss relaxation limiter set to sssrmx_scalar.'
         endif !1st tile
-        !sssrmx(:,:) = 99.9  !needed for thermf, set to no limit
         sssrmx(:,:) = sssrmx_scalar  !set according to NERSC namelist
       endif
 c
@@ -2623,19 +2622,17 @@ c --- check the input times.
       enddo
 c --- check the input times for forcing.riverh.
       if (highfq_river) then
-         do k= 918,918
-           if     (dtime(k).ne.dtime1) then
-             if     (mnproc.eq.1) then
+        if     (dtime(918).ne.dtime1) then
+           if     (mnproc.eq.1) then
              write(lp,*)
              write(lp,*) 'error in rdpall - inconsistent forcing times'
              write(lp,*) 'dtime0,dtime1 = ',dtime0,dtime1
              write(lp,*) 'dtime = ',dtime
              write(lp,*)
-             endif !1st tile
-             call xcstop('(rdpall)')
-                    stop '(rdpall)'
-           endif
-         enddo
+           endif !1st tile
+           call xcstop('(rdpall)')
+                  stop '(rdpall)'
+        endif
       endif! hihfq_river
       return
       end

--- a/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/forfun.F
+++ b/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/forfun.F
@@ -1512,9 +1512,7 @@ c
 #ifdef _FABM_
       use mod_hycom_fabm
 #endif
-#ifdef NERSC_HYCOM_CICE
-     use mod_NERSCnml, only : sssrmx_scalar
-#endif
+      use mod_NERSCnml
       implicit none
 c
 c --- initialize input of thermal/tracer relaxation forcing fields

--- a/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/forfun.F
+++ b/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/forfun.F
@@ -81,7 +81,7 @@ c --- units of seatmp are degC
 c --- units of vapmix are kg/k
 c --- units of mslprs are Pa     (anomaly, offset from total by prsbas)
 c --- units of precip are m/s    (positive into ocean)
-c --- units of river  are m/s    (positive into ocean)
+c --- units of rivers are m/s    (positive into ocean)
 c --- units of radflx are w/m^2  (positive into ocean)
 c --- units of swflx  are w/m^2  (positive into ocean)
 c --- units of offlux are w/m^2  (positive into ocean)
@@ -517,7 +517,7 @@ c --- units of seatmp are degC
 c --- units of vapmix are kg/kg
 c --- units of mslprs are Pa     (anomaly, offset from total by prsbas)
 c --- units of precip are m/s    (positive into ocean)
-c --- units of river  are m/s    (positive into ocean)
+c --- units of rivers are m/s    (positive into ocean)
 c --- units of radflx are w/m^2  (positive into ocean)
 c --- units of swflx  are w/m^2  (positive into ocean)
 c --- units of offlux are w/m^2  (positive into ocean)

--- a/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_NERSCnml.F90
+++ b/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_NERSCnml.F90
@@ -57,8 +57,9 @@ module mod_NERSCnml
     if (mnproc.eq.1) then
       write (lp,*)'NERSC HYCOM: Reading hycom_nml from: ./hycom_opt'
       write (lp,*)'NERSC HYCOM: Write arche    = ',write_arche
-      write (lp,*)'      HYCOM: sss_underice   = ',sss_underice
-      write (lp,*)'      HYCOM: highfq_river   = ',highfq_river
+      write (lp,*)'NERSC HYCOM: sss_underice   = ',sss_underice
+      write (lp,*)'NERSC HYCOM: highfq_river   = ',highfq_river
+      write (lp,*)'NERSC HYCOM: sssrmx_scalar = ',sssrmx_scalar
     endif !1st tile
     call xcsync(flush_lp)
 

--- a/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_NERSCnml.F90
+++ b/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_NERSCnml.F90
@@ -2,7 +2,7 @@ module mod_NERSCnml
 ! allow for namelist inputs in order to 
   use mod_xc
   use mod_za  ! HYCOM I/O interface
-
+  use mod_cb_arrays
   implicit none
   private
  
@@ -11,9 +11,8 @@ module mod_NERSCnml
 
   logical,save, public :: &
     write_arche, &      ! print arche files or not
-    sss_underice, &      ! relaxtion under ice (false if no) 
+    sss_underice, &     ! relaxtion under ice (false if no) 
     highfq_river        ! high frequency rivers (false if no) 
-
 
   public NERSC_init
 
@@ -33,7 +32,7 @@ module mod_NERSCnml
     sssrmx_scalar   = 99.0
 
     ! read namelist
-    open (funi, file='../hycom_opt', status='old',iostat=nml_err)
+    open (funi, file='./hycom_opt', status='old',iostat=nml_err)
     if (nml_err .ne. 0) then
       if  (mnproc.eq.1) then
         write (lp,'(a)') &
@@ -58,11 +57,20 @@ module mod_NERSCnml
       write (lp,*)'NERSC HYCOM: Reading hycom_nml from: ./hycom_opt'
       write (lp,*)'NERSC HYCOM: Write arche    = ',write_arche
       write (lp,*)'NERSC HYCOM: sss_underice   = ',sss_underice
+      write (lp,*)'NERSC HYCOM: sssrmx_scalar  = ',sssrmx_scalar
       write (lp,*)'NERSC HYCOM: highfq_river   = ',highfq_river
-      write (lp,*)'NERSC HYCOM: sssrmx_scalar = ',sssrmx_scalar
     endif !1st tile
+    call flush(lp)
+    if (priver .and. highfq_river) then
+        if (mnproc.eq.1) then
+           write(lp,*) &
+           'error - priver must be .false. for highfq_river=.true.'
+           call flush(lp)
+        endif !1st tile
+        call xcstop('(NERSC_nml)')
+        stop '(NERSC_nml)'
+    endif
     call xcsync(flush_lp)
-
   end subroutine NERSC_init
 
   !---------------------------------------------------------------------+

--- a/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_hycom.F
+++ b/hycom/RELO/src_2.2.98ZA-07Tsig0-i-sm-sse_relo_mpi/mod_hycom.F
@@ -1744,16 +1744,6 @@ c
 c --- initialize scalars
       call blkdat  !must call before zaiost
       call NERSC_init
-      if     (priver .and. highfq_river) then
-        if (mnproc.eq.1) then
-          write(lp,*)
-     &    'error - priver must be .false. for highfq_river=.true.'
-          call flush(lp)
-        endif !1st tile
-        call xcstop('(blkdat)')
-               stop '(blkdat)'
-      endif
-      
 c
 c --- initialize array i/o.
       call zaiost


### PR DESCRIPTION
Changes after review of code.

Check of priver and highfq_river moved into NERSC_init

In general we should decide if we want ifdef NERSC_HYCOM.... around namelist flags

Line 1987 If one wants to import rivers as in the priver case (cpl_orivers adn cpl__irivers) then this is can not be done. I dont think that it is necessary.

Updates to mod_NERSC to dump all values set by namelist.

Considerations not considered
We should allocate last dimension of rivers in case of high frequent rivers to 2 and not at all if there are no rivers.
Initialization of rivers are done twice. Maybe the function forfunhz is obsolete. (not done)

forfun line 3031. WHY is this 917 that is updated. Should it be 926?

forfun subroutine rdforf. Only called from yrflg less than 2. To follow high freq forcing it should be initialized here as well (if needed)