### PR TITLE
Hfreqriv2

### DIFF
--- a/TP5a0.06/expt_01.0/hycom_opt
+++ b/TP5a0.06/expt_01.0/hycom_opt
@@ -1,6 +1,5 @@
 &hycom_nml
   write_arche = .false.
   sss_underice= .false.
-  highfq_river= .false.
   sssrmx_scalar=99.
 /

--- a/TP5a0.06/expt_02.3/hycom_opt
+++ b/TP5a0.06/expt_02.3/hycom_opt
@@ -1,6 +1,5 @@
 &hycom_nml
   write_arche = .false.
   sss_underice= .false.
-  highfq_river= .false.
   sssrmx_scalar=99.
 /

--- a/bin/expt_preprocess.sh
+++ b/bin/expt_preprocess.sh
@@ -113,7 +113,6 @@ export IDM=$(blkdat_get blkdat.input idm)
 export JDM=$(blkdat_get blkdat.input jdm)
 export LWFLAG=`grep "'lwflag' =" blkdat.input | awk '{printf("%1d", $1)}'`
 
-export HRIVER=$(grep "highfq_river" ../hycom_opt | awk -F= '{printf("%s", $2)}' | tr -d ' \t\r\n')
 restarti=$(blkdat_get_string blkdat.input nmrsti "restart_in")
 
 # Add period to restart file name if not present...
@@ -383,7 +382,6 @@ if [ $FLXOFF -eq 1 ] ; then
     echo "fLxoff=F: No attempt to use flux offset correction" 
 fi
 
-
 # MOSTAFA: END
 
 #
@@ -391,13 +389,12 @@ fi
 # --- KAL: rivers are experiment-dependent
 #
 if [ $PRIVER -eq 0 ] ; then
-echo "**No river forcing. Set the priver to 1 to add river forcing"
-fi
-if [ $PRIVER -eq 1 ] ; then
-  echo "**Setting up river forcing  from priver"
+  echo "**No river forcing. Set the priver to 1 or 2 to add river forcing"
+elif [ $PRIVER -eq 1 ] ; then
+  echo "**Setting up climatological river forcing  from priver"
   cp $BASEDIR/force/rivers/$E/rivers.a forcing.rivers.a || tellerror "Could not get river .a file"
   cp $BASEDIR/force/rivers/$E/rivers.b forcing.rivers.b || tellerror "Could not get river .b file"
-   if [ $NTRACR -ne 0 ] ; then
+  if [ $NTRACR -ne 0 ] ; then
       echo "**Setting up bio river forcing"
       cp $BASEDIR/force/rivers/$E/ECO_no3.a rivers.ECO_no3.a || tellwarn "Could not get NO3 river .a file"
       cp $BASEDIR/force/rivers/$E/ECO_no3.b rivers.ECO_no3.b || tellwarn "Could not get NO3 river .b file"
@@ -406,27 +403,21 @@ if [ $PRIVER -eq 1 ] ; then
       cp $BASEDIR/force/rivers/$E/ECO_pho.a rivers.ECO_pho.a || tellwarn "Could not get PHO river .a file"
       cp $BASEDIR/force/rivers/$E/ECO_pho.b rivers.ECO_pho.b || tellwarn "Could not get PHO river .b file"
    fi
+elif [ $PRIVER -eq 2 ] ; then
+  echo "**Setting up high frequent river forcing  from priver" 
+  cp $BASEDIR/force/rivers/$E/rivers_highfrequent.a forcing.rivers.a || tellerror "Could not get river .a file"
+  cp $BASEDIR/force/rivers/$E/rivers_highfrequent.b forcing.rivers.b || tellerror "Could not get river .b file"
+  if [ $NTRACR -ne 0 ] ; then
+      echo "**Setting up bio river forcing"
+      cp $BASEDIR/force/rivers/$E/ECO_no3.a rivers.ECO_no3.a || tellwarn "Could not get NO3 river .a file"
+      cp $BASEDIR/force/rivers/$E/ECO_no3.b rivers.ECO_no3.b || tellwarn "Could not get NO3 river .b file"
+      cp $BASEDIR/force/rivers/$E/ECO_sil.a rivers.ECO_sil.a || tellwarn "Could not get SIL river .a file"
+      cp $BASEDIR/force/rivers/$E/ECO_sil.b rivers.ECO_sil.b || tellwarn "Could not get SIL river .b file"
+      cp $BASEDIR/force/rivers/$E/ECO_pho.a rivers.ECO_pho.a || tellwarn "Could not get PHO river .a file"
+      cp $BASEDIR/force/rivers/$E/ECO_pho.b rivers.ECO_pho.b || tellwarn "Could not get PHO river .b file"
+  fi
 fi
 
-if [ "$HRIVER" = ".true." ]; then
-  echo "Note: PRIVER must be 0 for highfq_river=true " 
-  echo "highfq_river=true: **Setting up high frequency river forcing  from hycom_opt highfq_river"
-  # Check range of file against start and stop times
-  RDIR=$BASEDIR/force/rivers/$E
-  if [ -f  $RDIR/riverh.a -a  -f $RDIR/riverh.b ] 
-  then
-     ln -sf $RDIR/riverh.a forcing.riverh.a || tellerror "Could not get riverh .a file"
-     ln -sf $RDIR/riverh.b forcing.riverh.b || tellerror "Could not get riverh .b file"
-     frcstart=$(head -n  6 forcing.riverh.b | tail -n1 | sed "s/.*=//" | sed "s/^[ ]*//" | cut -d " " -f 1)
-     frcstop=$(tail -n 1 forcing.riverh.b             | sed "s/.*=//" | sed "s/^[ ]*//" | cut -d " " -f 1)
-     test1=$(echo ${tstart#-}'>='$frcstart | bc -l)
-     test2=$(echo $tstop '<='$frcstop  | bc -l)
-     [ $test1 -eq 1 ] || tellerror "File $S/forcing.riverh.b: forcing starts after  model starts"
-     [ $test2 -eq 1 ] || tellerror "File $S/forcing.riverh.b: forcing stops  before model stops"
-  fi
-else
-    echo "highfq_river=false: No attemp to use high frequency river runnoff"
-fi
 #
 # --- kpar forcing
 #
@@ -644,7 +635,7 @@ else
 # --- changes to the model setup, this part should be commented out. 
 #
       imontg=0
-      if [ [ $tmp -eq 1 -o $tmp2 -eq 1 ] -a [ $imontg -eq 1] ]; then
+       if [ [ $tmp -eq 1 -o $tmp2 -eq 1 ] -a [ $imontg -eq 1] ]; then
          echo "debug: $(pwd)" 
          ### "Calculate and Write Montgometry potential into the nesting files"
          echo "filename="${filename}
@@ -663,7 +654,7 @@ else
            done
          done
          echo " Nesting Files Modified Successfully "
-      fi
+       fi
 #
 # --- End compute Montg. on the go, to be sure it is computed from the right nesting file.
 #     

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/blkdat.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/blkdat.F90
@@ -2198,7 +2198,8 @@
 ! --- thermo      use thermodynamic forcing 
 ! --- pensol      use penetrating solar radiation (input above)
 ! --- pcipf       use E-P forcing (may be redefined in forfun)
-! --- priver      rivers as a precipitation bogas
+! --- priver      rivers as a precipitation bogas priver=0 no river, priver=1 climatological river, priver=2: High frequent river
+! (like high frequent atm forcing)
 !
 ! --- srelax      activate surface salinity        climatological nudging
 ! --- trelax      activate surface temperature     climatological nudging
@@ -2219,7 +2220,7 @@
       endif !1st tile
       call blkinl(relax, 'relax ')
       call blkinl(trcrlx,'trcrlx')
-      call blkinl(priver,'priver')
+      call blkini(priver,'priver')
 !
 ! --- 'epmass' = E-P mass exchange flag (0=no,1=yes,2=river)
       call blkini(epmass,'epmass')
@@ -2228,10 +2229,10 @@
       write(lp,*)
       endif !1st tile
 !
-      if     (priver .and. .not.thermo) then
+      if     ((priver>0) .and. .not.thermo) then
         if (mnproc.eq.1) then
         write(lp,'(/ a /)')  &
-         &'error - priver must be .false. for flxflg=0'
+         &'error - priver must be 0 for flxflg=0'
         call flush(lp)
         endif !1st tile
         call xcstop('(blkdat)')
@@ -2946,3 +2947,4 @@
 !> Aug. 2024 - added ocnscl
 !> Sep. 2024 - added hybthk
 !> Dec. 2024 - Removed negative wndflg and amoflg due to inclusion of ocnscl
+!> May. 2026 - Changed priver to integer in order to allow for high frequent river

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/forfun.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/forfun.F90
@@ -1284,9 +1284,9 @@
 !
         lgth = len_trim(flnmfor)
 !
-        call zaiopf(flnmfor(1:lgth)//'forcing.riverh.a', 'old', 918)
+        call zaiopf(flnmfor(1:lgth)//'forcing.rivers.a', 'old', 918)
         if     (mnproc.eq.1) then  ! .b file from 1st tile only
-        open (unit=uoff+918,file=flnmfor(1:lgth)//'forcing.riverh.b', &
+        open (unit=uoff+918,file=flnmfor(1:lgth)//'forcing.rivers.b', &
            status='old', action='read')
         read (uoff+918,'(a79)') preambl
         endif !1st tile
@@ -1908,7 +1908,7 @@
 !
       if (thermo) then
 !
-      if     (.not.priver) then
+      if     (priver == 0) then
         if     (mnproc.eq.1) then
         write (lp,*)
         write (lp,*) '***** no river precipitation *****'
@@ -1917,7 +1917,7 @@
         call xcsync(flush_lp)
         rivers(:,:,:) = 0.0
         rivera = .true.  
-      else
+      elseif (priver == 1) then
         call zaiopf(flnmfor(1:lgth)//'forcing.rivers.a', 'old', 918)
         if     (mnproc.eq.1) then  ! .b file from 1st tile only
         open (unit=uoff+918,file=flnmfor(1:lgth)//'forcing.rivers.b', &
@@ -1937,7 +1937,7 @@
             rivers(:,:,l) = util1(:,:)
           enddo
           if     (mnproc.eq.1) then  ! .b file from 1st tile only
-          close (unit=uoff+918)
+            close (unit=uoff+918)
           endif
           call zaiocl(918)
 !diag     call prtmsk(ip,util1,util2,idm,idm,jdm,  0.,86400.*36000., &
@@ -1945,10 +1945,10 @@
         endif
       endif
 !
-      else  ! .not.thermo
-        rivers(:,:,:) = 0.0
-        priver = .false.
-        rivera = .true.  
+!      else  ! .not.thermo Till DMI: Can never enter here due to clause in blkdat.F90
+!        rivers(:,:,:) = 0.0
+!        priver = .false.
+!        rivera = .true.  
       endif                    !  thermo
 !
       if     (mnproc.eq.1) then

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/forfun.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/forfun.F90
@@ -633,9 +633,6 @@
       use mod_xc         ! HYCOM communication interface
       use mod_cb_arrays  ! HYCOM saved arrays
       use mod_za         ! HYCOM I/O interface
-#if defined(NERSC_HYCOM_CICE)
-      use mod_NERSCnml, only : highfq_river
-#endif
       implicit none
 !
       real*8    dtime
@@ -659,7 +656,6 @@
 ! --- units of spchum are kg/k
 ! --- units of mslprs are Pa     (anomaly, offset from total by prsbas)
 ! --- units of precip are m/s    (positive into ocean)
-! --- units of rivers are m/s    (positive into ocean)
 
 ! --- units of radflx are w/m^2  (positive into ocean)
 ! --- units of swflx  are w/m^2  (positive into ocean)
@@ -962,19 +958,6 @@
           call preambl_print(preambl)
         endif !surtmp
 !
-#if defined(NERSC_HYCOM_CICE)
-!ALF  --- read high frequency rivers----
-        if (highfq_river) then
-          call zaiopf(flnmfor(1:lgth)//'forcing.riverh.a', 'old', 918)
-          if     (mnproc.eq.1) then  ! .b file from 1st tile only
-          open (unit=uoff+918,file=flnmfor(1:lgth)//'forcing.riverh.b', &
-             status='old', action='read')
-          read (uoff+918,'(a79)') preambl
-          endif !1st tile
-          call preambl_print(preambl)
-        endif
-!End  --- read high frequency rivers----
-#endif
 #ifdef _FABM_
 !     CAGLAR: BEGIN (MAY2019)
           call zaiopf(flnmfor(1:lgth)//'forcing.dewpt.a', 'old', 926)
@@ -1140,13 +1123,6 @@
             call skmonth(909)
           enddo
         endif !surtmp
-#if defined(NERSC_HYCOM_CICE)
-        if (highfq_river) then
-          do i= 1,nrec-2
-            call skmonth(918)
-          enddo
-        endif
-#endif
 #ifdef _FABM_
           do i= 1,nrec-2
             call skmonth(926)
@@ -1271,6 +1247,195 @@
       return
 ! ESPC --- add
 # endif
+      end
+!
+!
+      subroutine readriver_hf(dtime,init)
+      use mod_xc         ! HYCOM communication interface
+      use mod_cb_arrays  ! HYCOM saved arrays
+      use mod_za         ! HYCOM I/O interface
+      implicit none
+!
+      real*8    dtime
+      logical init ! true if first call
+!
+! --- high frequency rivers field processing.
+! --- Only read either climatological rivers or readriver_hf
+!
+! --- units of rivers are m/s 
+!
+! --- I/O and array I/O unit 918 is reserved for the entire run.
+!
+      real*8    dtime0,dtime1
+      save      dtime0,dtime1
+!
+      character preambl(5)*79,cline*80
+      integer   i,ios,iunit,j,lgth,nrec
+!
+      if     (init) then
+        rivers(:,:,:) = 0.0
+!
+! ---   initialize forcing fields
+! ---   open high frequent river forcing file.
+        if     (mnproc.eq.1) then
+        write (lp,*) ' now initializing High frequent river fields ...'
+        endif !1st tile
+        call xcsync(flush_lp)
+!
+        lgth = len_trim(flnmfor)
+!
+        call zaiopf(flnmfor(1:lgth)//'forcing.riverh.a', 'old', 918)
+        if     (mnproc.eq.1) then  ! .b file from 1st tile only
+        open (unit=uoff+918,file=flnmfor(1:lgth)//'forcing.riverh.b', &
+           status='old', action='read')
+        read (uoff+918,'(a79)') preambl
+        endif !1st tile
+        call preambl_print(preambl)
+!
+! ---   skip ahead to the start time.
+        nrec   = 0
+        dtime1 = huge(dtime1)
+        do  ! infinate loop, with exit at end
+          dtime0 = dtime1
+          nrec   = nrec + 1
+          call zagetc(cline,ios, uoff+918)
+          if     (ios.ne.0) then
+            if     (mnproc.eq.1) then
+              write(lp,*)
+              write(lp,*) 'error in readriver_hf - hit end of input'
+              write(lp,*) 'dtime0,dtime1 = ',dtime0,dtime1
+              write(lp,*) 'dtime = ',dtime
+              write(lp,*)
+            endif !1st tile
+            call xcstop('(readriver_hf)')
+                   stop '(readriver_hf)'
+          endif
+          i = index(cline,'=')
+          read (cline(i+1:),*) dtime1
+          if     (yrflag.eq.2) then
+            if     (nrec.eq.1 .and. abs(dtime1-1096.0d0).gt.0.01) then
+!
+! ---         climatology must start on wind day 1096.0, 01/01/1904.
+              if     (mnproc.eq.1) then
+              write(lp,'(a)')  cline
+              write(lp,'(/ a,a / a,g15.6 /)') &
+                'error in readriver_hf - forcing climatology', &
+                ' must start on wind day 1096', &
+                'dtime1 = ',dtime1
+              endif !1st tile
+              call xcstop('(readriver_hf)')
+                     stop '(readriver_hf)'
+            endif
+            dtime1 = (dtime1 - 1096.0d0) +  &
+                     wndrep*int((dtime+0.00001d0)/wndrep)  !wndrep=366 or 732
+            if     (nrec.ne.1 .and. dtime1.lt.dtime0) then
+              dtime1 = dtime1 + wndrep
+            endif
+          elseif (yrflag.eq.4) then
+            if     (nrec.eq.1 .and. abs(dtime1-731.0d0).gt.0.01) then
+!
+! ---         climatology must start on wind day 731.0, 01/01/1903.
+              if     (mnproc.eq.1) then
+              write(lp,'(a)')  cline
+              write(lp,'(/ a,a / a,g15.6 /)') &
+                'error in readriver_hf - forcing climatology', &
+                ' must start on wind day 731', &
+                'dtime1 = ',dtime1
+              endif !1st tile
+              call xcstop('(readriver_hf)')
+                     stop '(readriver_hf)'
+            endif
+            dtime1 = (dtime1 - 731.0d0) +  &
+                     wndrep*int((dtime+0.00001d0)/wndrep)  !wndrep=365 or 731
+            if     (nrec.ne.1 .and. dtime1.lt.dtime0) then
+              dtime1 = dtime1 + wndrep
+            endif
+          elseif (nrec.eq.1 .and. dtime1.lt.1462.0d0) then
+!
+! ---       otherwise, must start after wind day 1462.0, 01/01/1905.
+            if     (mnproc.eq.1) then
+            write(lp,'(a)')  cline
+            write(lp,'(/ a,a / a,g15.6 /)') &
+              'error in readriver_hf - actual forcing', &
+              ' must start after wind day 1462', &
+              'dtime1 = ',dtime1
+            endif !1st tile
+            call xcstop('(readriver_hf)')
+                   stop '(readriver_hf)'
+          endif
+          if     (dtime0.le.dtime .and. dtime1.gt.dtime) then
+            exit
+          endif
+        enddo   ! infinate loop, with exit above
+        if     (mnproc.eq.1) then  ! .b file from 1st tile only
+          rewind(unit=uoff+918)
+          read (uoff+918,'(a79)') preambl
+        endif
+!
+        do i= 1,nrec-2
+          call skmonth(918)
+        enddo
+        dtime0 = huge(dtime1)
+        call rdpall1(rivers,dtime1,918,.true.)
+        if     (yrflag.eq.2) then
+          dtime1 = (dtime1 - 1096.0d0) +  &
+                   wndrep*int((dtime+0.00001d0)/wndrep)
+        elseif (yrflag.eq.4) then
+          dtime1 = (dtime1 - 731.0d0) +  &
+                   wndrep*int((dtime+0.00001d0)/wndrep)
+        endif
+        dtime0 = dtime1
+        call rdpall1(rivers,dtime1,918,.true.)
+        if     (yrflag.eq.2) then
+          dtime1 = (dtime1 - 1096.0d0) +  &
+                   wndrep*int((dtime+0.00001d0)/wndrep)  !wndrep=366 or 732
+          if     (dtime1.lt.dtime0) then
+            dtime1 = dtime1 + wndrep
+          endif
+        elseif (yrflag.eq.4) then
+          dtime1 = (dtime1 - 731.0d0) +  &
+                   wndrep*int((dtime+0.00001d0)/wndrep)  !wndrep=365 or 731
+          if     (dtime1.lt.dtime0) then
+            dtime1 = dtime1 + wndrep
+          endif
+        endif
+        if     (mnproc.eq.1) then
+        write (lp,*)
+        write (lp,*) ' dtime,dtime0,dtime1 = ',dtime,dtime0,dtime1
+        write (lp,*)
+        write (lp,*) ' ...finished initializing forcing fields'
+        endif !1st tile
+        call xcsync(flush_lp)
+      endif  ! initialization
+!
+      if     (dtime.gt.dtime1) then
+        dtime0 = dtime1
+        call rdpall1(rivers,dtime1,918,.true.)
+        if     (yrflag.eq.2) then
+          dtime1 = (dtime1 - 1096.0d0) +  &
+                   wndrep*int((dtime+0.00001d0)/wndrep)  !wndrep=366 or 732
+          if     (dtime1.lt.dtime0) then
+            dtime1 = dtime1 + wndrep
+          endif
+        elseif (yrflag.eq.4) then
+          dtime1 = (dtime1 - 731.0d0) +  &
+                   wndrep*int((dtime+0.00001d0)/wndrep)  !wndrep=365 or 731
+          if     (dtime1.lt.dtime0) then
+            dtime1 = dtime1 + wndrep
+          endif
+        endif
+      endif
+!
+! --- linear interpolation in time.
+      wr0 = (dtime1-dtime)/(dtime1-dtime0)
+      wr1 = 1.0 - wr0
+      if (mnproc.eq.1) then
+      write (lp,*) "river coefficients"
+      write (lp,'(2f8.4)') wr0, wr1
+      write (lp,*) dtime,dtime0,dtime1
+      call flush(lp)
+      endif
+      return
       end
 !
 !
@@ -1517,9 +1682,6 @@
       use mod_xc         ! HYCOM communication interface
       use mod_cb_arrays  ! HYCOM saved arrays
       use mod_za         ! HYCOM I/O interface
-#if defined(NERSC_HYCOM_CICE)
-      use mod_NERSCnml, only : highfq_river
-#endif
       implicit none
 !
 ! --- high frequency atmospheric forcing field processing.
@@ -1549,9 +1711,6 @@
              swflx(i,j,l) = 0.0
 #if defined(NERSC_HYCOM_CICE)
           swflxdwn(i,j,l) = 0.0
-          if (highfq_river) then
-            rivers(i,j,l) = 0.0
-          endif          
 #endif
             surtmp(i,j,l) = 0.0
             seatmp(i,j,l) = 0.0
@@ -2947,9 +3106,6 @@
       subroutine rdpall(dtime0,dtime1)
       use mod_xc         ! HYCOM communication interface
       use mod_cb_arrays  ! HYCOM saved arrays
-#if defined(NERSC_HYCOM_CICE)
-      use mod_NERSCnml, only : highfq_river
-#endif
       implicit none
 !
       real*8  dtime0,dtime1
@@ -3019,15 +3175,6 @@
       else
         dtime(906) = dtime(905)
       endif
-#if defined(NERSC_HYCOM_CICE)
-!ALFA  --- read high frequency rivers----
-      if (highfq_river) then
-        call rdpall1(rivers,dtime(918),918,mod(icall,3).eq.1)
-      else
-        dtime(918) = dtime(905)
-      endif
-!End  --- read high frequency rivers----
-#endif
 #ifdef _FABM_
 !CAGLAR
       dtime(917) = dtime(905)
@@ -3117,23 +3264,6 @@
                  stop '(rdpall)'
         endif
       enddo
-#if defined(NERSC_HYCOM_CICE)
-      if (highfq_river) then
-        do k= 918,918
-          if     (dtime(k).ne.dtime1) then
-            if     (mnproc.eq.1) then
-               write(lp,*)
-               write(lp,*) 'error in rdpall - inconsistent forcing times'
-               write(lp,*) 'dtime0,dtime1 = ',dtime0,dtime1
-               write(lp,*) 'dtime = ',dtime
-               write(lp,*)
-            endif !1st tile
-            call xcstop('(rdpall)')
-            stop '(rdpall)'
-          endif
-        enddo
-      endif
-#endif
       return
       end
 !
@@ -3264,9 +3394,6 @@
       use mod_xc         ! HYCOM communication interface
       use mod_cb_arrays  ! HYCOM saved arrays
       use mod_za         ! HYCOM I/O interface
-#if defined(NERSC_HYCOM_CICE)
-      use mod_NERSCnml, only : highfq_river 
-#endif
       implicit none
 !
       integer lslot,mnth
@@ -3500,9 +3627,6 @@
 #if defined(NERSC_HYCOM_CICE)
 !KAL
           swflxdwn(i,j,lslot) = 0.0
-          if (highfq_river) then
-            rivers(i,j,lslot) = 0.0
-          endif
 #endif
           enddo
         enddo

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_NERSCnml.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_NERSCnml.F90
@@ -2,7 +2,6 @@ module mod_NERSCnml
 ! allow for namelist inputs in order to 
   use mod_xc
   use mod_za  ! HYCOM I/O interface
-  use mod_cb_arrays, only: priver
   implicit none
   private
  
@@ -11,8 +10,7 @@ module mod_NERSCnml
 
   logical,save, public :: &
     write_arche, &      ! print arche files or not
-    sss_underice, &     ! relaxtion under ice (false if no) 
-    highfq_river        ! high frequency rivers (false if no) 
+    sss_underice        ! relaxtion under ice (false if no) 
 
   public NERSC_init
 
@@ -24,11 +22,10 @@ module mod_NERSCnml
     implicit none
     integer (4), parameter :: funi=503
     integer (4) :: nml_err
-    namelist /hycom_nml/ write_arche,sss_underice,highfq_river,sssrmx_scalar
+    namelist /hycom_nml/ write_arche,sss_underice,sssrmx_scalar
     !default values
     write_arche     = .false.
     sss_underice    = .false.
-    highfq_river    = .false.
     sssrmx_scalar   = 99.0
 
     ! read namelist
@@ -58,18 +55,8 @@ module mod_NERSCnml
       write (lp,*)'NERSC HYCOM: Write arche    = ',write_arche
       write (lp,*)'NERSC HYCOM: sss_underice   = ',sss_underice
       write (lp,*)'NERSC HYCOM: sssrmx_scalar  = ',sssrmx_scalar
-      write (lp,*)'NERSC HYCOM: highfq_river   = ',highfq_river
     endif !1st tile
     call flush(lp)
-    if (priver .and. highfq_river) then
-        if (mnproc.eq.1) then
-           write(lp,*) &
-           'error - priver must be .false. for highfq_river=.true.'
-           call flush(lp)
-        endif !1st tile
-        call xcstop('(NERSC_nml)')
-        stop '(NERSC_nml)'
-    endif
     call xcsync(flush_lp)
   end subroutine NERSC_init
 

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_cb_arrays.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_cb_arrays.F90
@@ -352,7 +352,7 @@
 !
       logical, save :: &
                     btrlfr,btrmas,diagno,thermo,windf,mslprf, &
-                    pcipf,priver,rivera,kparan,lbmont, &
+                    pcipf,rivera,kparan,lbmont, &
                     relax,srelax,trelax,trcrlx,relaxf,relaxs,relaxt, &
                     locsig,vsigma,hybrid,isopyc,icegln,hybraf,isopcm, &
                     mxl_no,mxlkta,mxlktb,mxlkrt,pensol, &
@@ -361,6 +361,8 @@
                     mxlmy,mxlpwp,mxlgiss, &
                     stroff,flxoff,flxsmo,trcrin,trcout, &
                     dsur1p,arcend
+
+      integer,save  :: priver
 !
 ! ---  t e x t
 ! ---  ctitle     four lines describing the simulation
@@ -1929,3 +1931,4 @@
 !> Aug. 2024 - added ocnscl
 !> Sep. 2024 - added hybthk
 !> Dec. 2024 - removed amoflg
+!> May. 2026 - changed priver from logical to integer

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_hycom.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_hycom.F90
@@ -2471,6 +2471,8 @@
            call rdrivr(mr2,lr2)
            call rdrivr(mr3,lr3)
 #endif /* USE_NUOPC_CESMBETA:else */
+      elseif (highfq_river) then
+           call readriver_hf(dtime0,.true.)
       endif
 !
       if     (clmflg.eq.12) then
@@ -3071,6 +3073,8 @@
             wr0=-.5*x *x1*x1
             wr3=-.5*x1*x *x
          endif
+      elseif (highfq_river) then
+         call readriver_hf(dtime,.false.)
       endif
 !
 ! --- set weights for quasi-hermite time interpolation for temperature,

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_hycom.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_hycom.F90
@@ -38,7 +38,7 @@
       use mod_hycom_fabm
 #endif
 #if defined(NERSC_HYCOM_CICE)
-      use mod_NERSCnml, only : write_arche, nersc_init, highfq_river
+      use mod_NERSCnml, only : write_arche, nersc_init
 #endif
 !
 ! --- -----------------------------------------
@@ -1958,19 +1958,15 @@
       elseif (jerlv0.eq.-1) then
         call forfunc  !  annual/monthly chl
       endif
-#if defined(NERSC_HYCOM_CICE)
-      if (highfq_river) then
+      if (priver == 2) then
         if (mnproc.eq.1) then
           write(lp,*) &
-         '--- Skipping the monthly river inflow----'
+         '--- High frequent river inflow----'
           call flush(lp)
         endif !1st tile
       else
          call forfunp  !    annual/monthly rivers
       endif
-#else
-      call forfunp  !    annual/monthly rivers
-#endif 
       call forfunr  ! bimonthly/monthly climatology
       watcum=0.
       empcum=0.
@@ -2447,7 +2443,7 @@
         call rdkpar(mk3,lk3)
       endif
 !
-      if (priver) then
+      if (priver == 1) then
 ! ---   read in rivers field for 4 consecutive months
         mr1=1.+mod(dtime0+dyear0,dyear)/dmonth
         mr0=mod(mr1+10,12)+1
@@ -2471,7 +2467,7 @@
            call rdrivr(mr2,lr2)
            call rdrivr(mr3,lr3)
 #endif /* USE_NUOPC_CESMBETA:else */
-      elseif (highfq_river) then
+      elseif (priver == 2) then
            call readriver_hf(dtime0,.true.)
       endif
 !
@@ -3050,7 +3046,7 @@
       endif
 !
 ! --- set weights for quasi-hermite time interpolation for rivers.
-      if     (priver) then
+      if     (priver == 1) then
          if (.not. (cpl_orivers .and. cpl_irivers)) then
 ! ---   monthly fields.
             x=1.+mod(dtime+dyear0,dyear)/dmonth
@@ -3073,8 +3069,10 @@
             wr0=-.5*x *x1*x1
             wr3=-.5*x1*x *x
          endif
-      elseif (highfq_river) then
-         call readriver_hf(dtime,.false.)
+      elseif (priver == 2) then
+         if (.not. (cpl_orivers .and. cpl_irivers)) then
+            call readriver_hf(dtime,.false.)
+         endif
       endif
 !
 ! --- set weights for quasi-hermite time interpolation for temperature,

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/thermf.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/thermf.F90
@@ -1131,9 +1131,6 @@
 #ifdef CPL_OASIS_HYCOM
       use mod_cpl_oasis_init
 #endif
-#if defined (NERSC_HYCOM_CICE)
-      use mod_NERSCnml, only : highfq_river
-#endif
 
       implicit none
 !
@@ -1976,7 +1973,7 @@
 ! --- wtrflx = water flux (m/s kg/m**3) into ocean
       wtrflx(i,j)=-emnp*rhoref
 ! --- allow for rivers as a precipitation bogas (m/s kg/m**3)
-      if     (priver) then
+      if     (priver == 1) then
         if(cesmbeta .and. cpl_orivers.and.cpl_irivers) then
             rivflx(i,j) = (imp_orivers(i,j,1)+imp_irivers(i,j,1)) &
                         * rhoref
@@ -1987,7 +1984,7 @@
         endif
 !       wtrflx(i,j) = wtrflx(i,j)+rivflx(i,j) !update wtrflx in thermf_oi
 #if defined(NERSC_HYCOM_CICE)
-      elseif (highfq_river) then
+      elseif (priver == 2) then
         rivflx(i,j) = ( rivers(i,j,1)*wr0+rivers(i,j,2)*wr1)   &
                     * rhoref
 #endif

--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/thermf.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/thermf.F90
@@ -904,7 +904,7 @@
       enddo
 !$OMP END PARALLEL DO
 !
-      if     (.false. .and. itest.gt.0 .and. jtest.gt.0) then
+      if     (.true. .and. itest.gt.0 .and. jtest.gt.0) then
         write(lp,'(i9,2i5,a/19x,4f10.4)') &
           nstep,i0+itest,j0+jtest, &
           '    sstflx     ustar    hekman    surflx', &
@@ -912,13 +912,16 @@
           ustar( itest,jtest), &
           hekman(itest,jtest), &
           surflx(itest,jtest)
-        write(lp,'(i9,2i5,a/19x,4f10.4)') &
-          nstep,i0+itest,j0+jtest, &
+        write(lp,'(i9,2i5,2f8.4,a/19x,4f10.4)') &
+          nstep,i0+itest,j0+jtest, wr0,wr1, & 
           '    sswflx     wtrflx   rivflx    sssflx', &
           sswflx(itest,jtest), &
           wtrflx(itest,jtest), &
           rivflx(itest,jtest), &
           sssflx(itest,jtest)
+          write(lp,*) rivflx(itest,jtest)
+          write(lp,*) rivers(itest,jtest,1),rivers(itest,jtest,2)
+      call flush(lp)
       endif !test
 !
 ! --- smooth surface fluxes?
@@ -1985,7 +1988,7 @@
 !       wtrflx(i,j) = wtrflx(i,j)+rivflx(i,j) !update wtrflx in thermf_oi
 #if defined(NERSC_HYCOM_CICE)
       elseif (highfq_river) then
-        rivflx(i,j) = ( rivers(i,j,l0)*w0+rivers(i,j,l1)*w1)   &
+        rivflx(i,j) = ( rivers(i,j,1)*wr0+rivers(i,j,2)*wr1)   &
                     * rhoref
 #endif
       else


### PR DESCRIPTION
Replaces #333 due to contamination in the previous pull request
This pull request allows for flexible read of forcing.rivers.[ab].
I have used the climatology as test with a changed .b file. See below.
highfq_river has been replaced with priver = 2. 

Then priver = 0 (no rivers)., priver =1 (climatological rivers), priver = 2 (high frequenet)
Teest with priver = 0 and priver = 1 are both binary identical.
I am running a one year test where the integer month has been replaced with 

Scripts has also been modified in order to accommodate  this change.

The debug outputs should be remove before this is merged.

@AlfaAli how would you check whether one is trying to read climatology or high frequent rivers?

The only difference is that the high-frequent has real values (hycomdate) after the "=" whereas the climatology has month as integer  e.g. "01". It will fail when it tries to read. I think that the obvious place to put a check like that is in the forfun functions.

Note I will start a test where I mimic the climatology with the high frequent by setting the time stamps for each month to hycomdate(1/1-1993), hycomdate(1/2-1993)...hycomdate(1/1-1994)
-------------------------------Example of .b file-----------------------------------------
Tot. river mass flux from Hype + Greenland(TRIP rivers+ ice melt)
b
c
d
i/jdm = 800 760
rivers:dtime1,range = 33604.0000 0.000 0.00000000e+00 5.72921408e-07
rivers:dtime1,range = 33605.0000 0.000 0.00000000e+00 4.21341696e-07
rivers:dtime1,range = 33606.0000 0.000 0.00000000e+00 4.07051317e-07
rivers:dtime1,range = 33607.0000 0.000 0.00000000e+00 1.25661256e-06
rivers:dtime1,range = 33608.0000 0.000 0.00000000e+00 6.32963247e-06
rivers:dtime1,range = 33609.0000 0.000 0.00000000e+00 5.50549885e-06
rivers:dtime1,range = 33610.0000 0.000 0.00000000e+00 2.59040189e-06
rivers:dtime1,range = 33611.0000 0.000 0.00000000e+00 1.69854536e-06
rivers:dtime1,range = 33612.0000 0.000 0.00000000e+00 1.67057442e-06
rivers:dtime1,range = 33612.5000 0.000 0.00000000e+00 1.83761983e-06
rivers:dtime1,range = 33613.0000 0.000 0.00000000e+00 1.82023530e-06
rivers:dtime1,range = 33614.0000 0.000 0.00000000e+00 1.16410411e-06