### PR TITLE
Update `.gitignore` to cover new build artifacts and data directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,9 @@ pythonlibs/*/build/
 pythonlibs/*/*.egg-info/
 #--------
 #--------
-NMOb0.08/
+NMOb0.08/topo
+NMOb0.08/subregion
+NMOb0.08/expt_01.0/data/
 #--------
 #--------
 hycom/MSCPROGS/bin*/

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,16 @@
 *~
 #--------
 #--------
+.ipynb_checkpoints/
+#--------
+#--------
+pythonlibs/*/build/
+pythonlibs/*/*.egg-info/
+#--------
+#--------
+NMOb0.08/
+#--------
+#--------
 hycom/MSCPROGS/bin*/
 hycom/MSCPROGS/bin/
 hycom/MSCPROGS/bin
@@ -85,7 +95,9 @@ hycom/hycom_ALL/hycom_2.2.72_ALL/relax/src_2.2.35/relaxi_archvz
 hycom/hycom_ALL/hycom_2.2.72_ALL/relax/src_2.2.35/z_woa_dynamic
 hycom/hycom_ALL/hycom_2.2.72_ALL/relax/src_2.2.35/Make_nemo_archvz_modified
 hycom/hycom_ALL/hycom_2.2.72_ALL/relax/src_2.2.35/Make_relaxi_nemo
+hycom/hycom_ALL/hycom_2.2.72_ALL/relax/src_2.2.35/Make_rmu_linear
 hycom/hycom_ALL/hycom_2.2.72_ALL/relax/src_2.2.35/nemo_archvz_modified
+hycom/hycom_ALL/hycom_2.2.72_ALL/relax/src_2.2.35/rmu_linear
 hycom/hycom_ALL/hycom_2.2.72_ALL/topo/src_2.2.72/Make_tiles
 hycom/hycom_ALL/hycom_2.2.72_ALL/topo/src_2.2.72/topo_tiles
 hycom/hycom_ALL/hycom_2.2.72_ALL/topo/src_2.2.72/topo_zthin
@@ -110,8 +122,11 @@ hycom/MSCPROGS/src/GridToLL/findnearest
 hycom/MSCPROGS/src/GridToLL/gridtoll
 hycom/MSCPROGS/src/Hyc2proj/hyc2proj
 hycom/MSCPROGS/src/Hyc2proj/hyc2stations
+hycom/MSCPROGS/src/Hyc2proj/TMP/
 hycom/MSCPROGS/src/IceDrift/icedrift2
 hycom/MSCPROGS/src/IceDrift/icedrift_osisaf
+hycom/MSCPROGS/src/IceDriftNC/TMP/
+hycom/MSCPROGS/src/IceDriftNC/icedrift_osisafNC
 hycom/MSCPROGS/src/Idealized_Grid/igrid
 hycom/MSCPROGS/src/Idealized_Grid/irstrt
 hycom/MSCPROGS/src/MkEnsemble/create_single_mem
@@ -122,6 +137,8 @@ hycom/MSCPROGS/src/Model_input-2.2.37/thkdf4-2.2.37
 hycom/MSCPROGS/src/Nersclib/libconfmap.a
 hycom/MSCPROGS/src/Nersclib/libhycnersc.a
 hycom/MSCPROGS/src/Relax/rmunew
+hycom/MSCPROGS/src/Relax/z_norcpm
+hycom/MSCPROGS/src/Relax/z_noresm
 hycom/MSCPROGS/src/Relax/z_woa2013_bio
 hycom/MSCPROGS/src/RelaxToNetCDF/hclimlevels
 hycom/MSCPROGS/src/RelaxToNetCDF/hclimtonc


### PR DESCRIPTION
Adds entries for several previously untracked file categories, all consistent with the existing .gitignore patterns:

  - .ipynb_checkpoints/ — Jupyter notebook checkpoint directories
  - pythonlibs/*/build/ and pythonlibs/*/*.egg-info/ — Python package build artifacts
  - NMOb0.08/topo, NMOb0.08/subregion, NMOb0.08/expt_01.0/data/ — local model domain data (binary .a/.b grid and depth files)
  - hycom/MSCPROGS/src/Hyc2proj/TMP/ and hycom/MSCPROGS/src/IceDriftNC/TMP/ — compiler temp directories
  - hycom/MSCPROGS/src/IceDriftNC/icedrift_osisafNC, z_norcpm, z_noresm — compiled binaries
  - hycom/hycom_ALL/.../Make_rmu_linear and rmu_linear — Makefile and compiled binary for the rmu_linear tool