### PR TITLE
Fix race condition in archvz2hycom_biophys.sh parallel jobs

### DIFF
--- a/bin/archvz2hycom_biophys.sh
+++ b/bin/archvz2hycom_biophys.sh
@@ -278,7 +278,7 @@ create_blkdat_subset_function(){
       if [ ! -s  blkdat.subset ] ; then
          echo "Couldnt get blkdat.input " ; exit 1 ;
       fi
-      rm -rf fort.*
+      rm -f fort.99
       mv blkdat.subset fort.99
 }
 # Extract 'iexpt' value from blkdat.input and fort.99

--- a/bin/archvz2hycom_biophys.sh
+++ b/bin/archvz2hycom_biophys.sh
@@ -278,7 +278,6 @@ create_blkdat_subset_function(){
       if [ ! -s  blkdat.subset ] ; then
          echo "Couldnt get blkdat.input " ; exit 1 ;
       fi
-      rm -f fort.99
       mv blkdat.subset fort.99
 }
 # Extract 'iexpt' value from blkdat.input and fort.99

--- a/bin/archvz2hycom_biophys.sh
+++ b/bin/archvz2hycom_biophys.sh
@@ -31,9 +31,10 @@ usage="
 nlayers=50
 grid_type=native
 bio_flag=0
+setup_only=0
 
 # This will process optional arguments
-options=$(getopt -o b:gn: -- "$@")
+options=$(getopt -o b:gn: -l setup-only -- "$@")
 [ $? -eq 0 ] || {
     echo "$usage"
     echo "Error: Incorrect options provided"
@@ -52,6 +53,9 @@ while true; do
     -n)
         shift;
         nlayers=$1
+        ;;
+    --setup-only)
+        setup_only=1
         ;;
     --)
         shift
@@ -102,6 +106,46 @@ export N=${BASEDIR}/subregion/${E}
 export NEST=${newregionpath}/nest/${E}
 export EXPTNEW=${newregionpath}/expt_${X}
 #
+create_blkdat_subset_function(){
+      echo "Retrieve blkdat.input and create subset"
+      touch blkdat.subset
+      rm    blkdat.subset
+      echo "NEMO Relaxation fields"                              > blkdat.subset
+      echo "  $SIGVERSN        'sigver ' = Version of eqn of state  "                        >> blkdat.subset
+      echo "  1        'levtop ' = top level of input clim. to use (optional, default 1)"  >> blkdat.subset
+      egrep "'iversn'"    blkdat.input >> blkdat.subset
+      egrep "'iexpt '"    blkdat.input >> blkdat.subset
+      egrep "'mapflg'"    blkdat.input >> blkdat.subset
+      egrep "'yrflag'"    blkdat.input >> blkdat.subset
+      egrep "'idm   '"    blkdat.input >> blkdat.subset
+      egrep "'jdm   '"    blkdat.input >> blkdat.subset
+      echo "  0        'jdw    ' = width of zonal average (optional, default 0)"  >> blkdat.subset
+      echo "  -1       'itest  ' = grid point where detailed diagnostics are desired"  >> blkdat.subset
+      echo "  -1       'jtest  ' = grid point where detailed diagnostics are desired"  >> blkdat.subset
+      egrep "'kdm   '"    blkdat.input >> blkdat.subset
+      egrep "'nhybrd'"    blkdat.input >> blkdat.subset
+      egrep "'nsigma'"    blkdat.input >> blkdat.subset
+      egrep "'isotop'"    blkdat.input >> blkdat.subset
+      egrep "'dp00  '"    blkdat.input >> blkdat.subset
+      egrep "'dp00x '"    blkdat.input >> blkdat.subset
+      egrep "'dp00f '"    blkdat.input >> blkdat.subset
+      egrep "'ds00  '"    blkdat.input >> blkdat.subset
+      egrep "'ds00x '"    blkdat.input >> blkdat.subset
+      egrep "'ds00f '"    blkdat.input >> blkdat.subset
+      egrep "'ds0k  '"    blkdat.input >> blkdat.subset
+      egrep "'dp0k  '"    blkdat.input >> blkdat.subset
+      egrep "'dp00i '"    blkdat.input >> blkdat.subset
+      egrep "'thflag'"    blkdat.input >> blkdat.subset
+      egrep "'thbase'"    blkdat.input >> blkdat.subset
+      egrep "'vsigma'"    blkdat.input >> blkdat.subset
+      egrep "'sigma '"    blkdat.input >> blkdat.subset
+      egrep "'thkmin'"    blkdat.input >> blkdat.subset
+      if [ ! -s  blkdat.subset ] ; then
+         echo "Couldnt get blkdat.input " ; exit 1 ;
+      fi
+      mv blkdat.subset fort.99
+}
+
 mkdir -p $N
 mkdir -p $NEST
 mkdir -p $D
@@ -141,6 +185,26 @@ if [ ! -f $N/ZL${nlayers}.txt -o ! -f $N/blkdat.input ] ; then
    cp  ${BASEDIR}/topo/ZL${nlayers}.txt                  $N/ZL${nlayers}.txt
    cp  ${EXPTNEW}/blkdat.input                   $N/blkdat.input
 fi
+
+if [ "${setup_only}" -eq 1 ]; then
+    cd $N
+    iexpt_blkdat_input=$(grep "'iexpt '" blkdat.input | awk '{print $1}')
+    if [ -f fort.99 ] ; then
+        iexpt_fort99=$(grep "'iexpt '" fort.99 | awk '{print $1}')
+        if [ "$iexpt_blkdat_input" -eq "$iexpt_fort99" ]; then
+            echo "fort.99 is up to date."
+        else
+            echo "fort.99 is from an old experiment. Recreating."
+            create_blkdat_subset_function
+        fi
+    else
+        echo "Creating fort.99."
+        create_blkdat_subset_function
+    fi
+    echo "Setup complete."
+    exit 0
+fi
+
 echo "Inner domain topo: depth_${U}_${T}.b" 
 #
 #   idm, jdm, & kdm from target xperiment blkdat.input
@@ -239,47 +303,6 @@ touch   ${target_archv}.b && rm ${target_archv}.b
 logfile=${N}/nemo_archv.log
 touch $logfile && rm $logfile
 
-# modified for shell parallel runs
-create_blkdat_subset_function(){
-      echo "Retrieve blkdat.input and create subset"
-      touch blkdat.subset
-      rm    blkdat.subset
-      #echo "" > blkdat.subset
-      echo "NEMO Relaxation fields"                              > blkdat.subset
-      echo "  $SIGVERSN        'sigver ' = Version of eqn of state  "                        >> blkdat.subset
-      echo "  1        'levtop ' = top level of input clim. to use (optional, default 1)"  >> blkdat.subset
-      egrep "'iversn'"    blkdat.input >> blkdat.subset
-      egrep "'iexpt '"    blkdat.input >> blkdat.subset
-      egrep "'mapflg'"    blkdat.input >> blkdat.subset
-      egrep "'yrflag'"    blkdat.input >> blkdat.subset
-      egrep "'idm   '"    blkdat.input >> blkdat.subset
-      egrep "'jdm   '"    blkdat.input >> blkdat.subset
-      echo "  0        'jdw    ' = width of zonal average (optional, default 0)"  >> blkdat.subset
-      echo "  -1       'itest  ' = grid point where detailed diagnostics are desired"  >> blkdat.subset
-      echo "  -1       'jtest  ' = grid point where detailed diagnostics are desired"  >> blkdat.subset
-      egrep "'kdm   '"    blkdat.input >> blkdat.subset
-      egrep "'nhybrd'"    blkdat.input >> blkdat.subset
-      egrep "'nsigma'"    blkdat.input >> blkdat.subset
-      egrep "'isotop'"    blkdat.input >> blkdat.subset
-      egrep "'dp00  '"    blkdat.input >> blkdat.subset
-      egrep "'dp00x '"    blkdat.input >> blkdat.subset
-      egrep "'dp00f '"    blkdat.input >> blkdat.subset
-      egrep "'ds00  '"    blkdat.input >> blkdat.subset
-      egrep "'ds00x '"    blkdat.input >> blkdat.subset
-      egrep "'ds00f '"    blkdat.input >> blkdat.subset
-      egrep "'ds0k  '"    blkdat.input >> blkdat.subset
-      egrep "'dp0k  '"    blkdat.input >> blkdat.subset
-      egrep "'dp00i '"    blkdat.input >> blkdat.subset
-      egrep "'thflag'"    blkdat.input >> blkdat.subset
-      egrep "'thbase'"    blkdat.input >> blkdat.subset
-      egrep "'vsigma'"    blkdat.input >> blkdat.subset
-      egrep "'sigma '"    blkdat.input >> blkdat.subset
-      egrep "'thkmin'"    blkdat.input >> blkdat.subset
-      if [ ! -s  blkdat.subset ] ; then
-         echo "Couldnt get blkdat.input " ; exit 1 ;
-      fi
-      mv blkdat.subset fort.99
-}
 # Extract 'iexpt' value from blkdat.input and fort.99
 iexpt_blkdat_input=$(grep "'iexpt '" blkdat.input | awk '{print $1}')
 if [ -f fort.99 ] ; then


### PR DESCRIPTION
## Problem

When `archvz2hycom_biophys.sh` is invoked in parallel (one process per archive file), all jobs share the same `subregion/` working directory. This caused two race conditions:

1.` blkdat.subset` write collision: concurrent jobs appended to the same temp file, producing a corrupted `fort.99`.
2. `rm -rf fort.*` deletion: one job deleted `fort.99` while another job's Fortran program was reading it, causing a crash and silently missing output files.

## Fix

- Remove `rm -rf fort.*` (the atomic mv `blkdat.subset fort.99` makes it unnecessary).
- Add a `--setup-only` flag to `archvz2hycom_biophys.sh`. When called with this flag, the script runs only the one-time setup (copying grid/topo files, creating `fort.99`) and exits. The caller runs this once before the parallel loop. Since the existing `if [ ! -f ]` guards on file copies and the iexpt check on `fort.99` cause parallel jobs to skip setup entirely, all races are eliminated.

## New workflow (example)

Here is an example script for the suggested workflow:

```bash
CONFIGNAME=<CONFIGNAME>   # e.g. TP2a0.10
EXPT_ID=<EXPT_ID>         # e.g. 01.0

source ${HOME}/NERSC-HYCOM-CICE/environment/betzy_env.sh
module load Miniforge3/24.1.2-0
source ${EBROOTMINIFORGE3}/bin/activate
conda activate hycom-cice

MAX_PARALLEL=12  # each job uses ~16 GB peak; 12 × 16 GB = 192 GB with headroom

START=2018-01-01
END=2018-01-31

cd $HOME/NERSC-HYCOM-CICE/NMOb0.08/expt_01.0
$HOME/NERSC-HYCOM-CICE/bin/archvz2hycom_biophys.sh --setup-only $WORK/${CONFIGNAME}/expt_${EXPT_ID}/

DATE=$START
nproc=0
while [[ "$DATE" < "$END" || "$DATE" == "$END" ]]; do
    YYYY=$(date -d "$DATE" +%Y)
    YYYYMMDD=$(date -d "$DATE" +%Y%m%d)
    $HOME/NERSC-HYCOM-CICE/bin/nemo_to_hycom.sh \
        -d $WORK/${CONFIGNAME}/expt_${EXPT_ID}/ \
        -n "$WORK/input/GLORYS12/PHY/${YYYY}/MERCATOR-PHY-24-${DATE}-12.nc" \
        -g regular \
        -b "$WORK/input/GLORYS12/BIO/${YYYY}/global_analysis_forecast_bio_${YYYYMMDD}.nc" \
        -m "$WORK/input/GLORYS12/GLO-MFC_001_030_mask_bathy.nc" \
        -c "$WORK/input/GLORYS12/GLO-MFC_001_030_coordinates.nc" &
    nproc=$((nproc+1))
    if [ $nproc -ge $MAX_PARALLEL ]; then
        wait
        nproc=0
    fi
    DATE=$(date -d "$DATE + 1 day" +%Y-%m-%d)
done
wait
```
