### PR TITLE
Fix stray "done" and empty `pbsjob*.sh` artifact in job scripts

### DIFF
--- a/TP2a0.10/expt_01.0/srjob.sh
+++ b/TP2a0.10/expt_01.0/srjob.sh
@@ -52,7 +52,7 @@ srun -n $NMPI --cpu_bind=cores ./hycom_cice
 
 # Cleanup and move data files to data directory - must be in "expt_XXX" dir for this script
 cd $P     ||  { echo "Could not go to dir $P  "; exit 1; }
-../expt_postprocess.sh 
+../bin/expt_postprocess.sh 
 
 exit $?
 

--- a/TP2a0.10/expt_01.0/srjob.sh
+++ b/TP2a0.10/expt_01.0/srjob.sh
@@ -54,7 +54,5 @@ srun -n $NMPI --cpu_bind=cores ./hycom_cice
 cd $P     ||  { echo "Could not go to dir $P  "; exit 1; }
 ../expt_postprocess.sh 
 
-done
-
 exit $?
 

--- a/bin/expt_new.sh
+++ b/bin/expt_new.sh
@@ -80,6 +80,7 @@ rm blkdat.input.tmp
 
 # Modify pbs job scripts with descriptive id
 for i in pbsjob*.sh ; do
+   [ -f "$i" ] || continue
    mv $i $i.tmp
    cat $i.tmp | sed "s/PBS[ ]*-N.*$/PBS -N ${R}_X${X}/"  > $i
 done


### PR DESCRIPTION
This PR fixes two small bugs:

* It removes a stray "done" in the `srjob.sh` template.
* It fixes glob in `expt_new.sh` creating empty `pbsjob*.sh` artifact when no PBS scripts exist.