### PR TITLE
Hriver run fix

### DIFF
--- a/bin/river-topaz/scripts/GloFAS/GloFAS_grid.py
+++ b/bin/river-topaz/scripts/GloFAS/GloFAS_grid.py
@@ -310,18 +310,15 @@ class GloFAS_grid:
             Yenisei=(70.90,83.30) #idx 268
             Ob=(66.5,69.8) #idx 234
 
-            distance_to_lena = np.sqrt((self.df_dis_Estuary['latitude'] - Lena[0]) ** 2 + (self.df_dis_Estuary['longitude'] - Lena[1]) ** 2)
+            # Cache estuary indices for the 3 rivers — positions don't change between days
+            if not hasattr(self, '_russian_river_indices'):
+                self._russian_river_indices = {
+                    'Lena':    int(np.sqrt((self.df_dis_Estuary['latitude'] - Lena[0]   )**2 + (self.df_dis_Estuary['longitude'] - Lena[1]   )**2).argmin()),
+                    'Yenisei': int(np.sqrt((self.df_dis_Estuary['latitude'] - Yenisei[0])**2 + (self.df_dis_Estuary['longitude'] - Yenisei[1])**2).argmin()),
+                    'Ob':      int(np.sqrt((self.df_dis_Estuary['latitude'] - Ob[0]     )**2 + (self.df_dis_Estuary['longitude'] - Ob[1]     )**2).argmin()),
+                }
 
-            distance_to_yenisei = np.sqrt((self.df_dis_Estuary['latitude'] - Yenisei[0]) ** 2 + (self.df_dis_Estuary['longitude'] - Yenisei[1]) ** 2)
-
-            distance_to_ob = np.sqrt((self.df_dis_Estuary['latitude'] - Ob[0]) ** 2 + (self.df_dis_Estuary['longitude'] - Ob[1]) ** 2)
-
-            #We'll find the indices for the 3 rivers, we know what they should be but it may change with GloFAS version
-            idx_Lena=distance_to_lena.argmin()
-            idx_Yenisei=distance_to_yenisei.argmin()
-            idx_Ob=distance_to_ob.argmin()
-
-            IDX={'Lena':idx_Lena,'Yenisei':idx_Yenisei,'Ob':idx_Ob}
+            IDX = self._russian_river_indices
 
             for river in correction.river.data:
                 idx=IDX[river]
@@ -360,8 +357,6 @@ class GloFAS_grid:
 
         if re_propagate==False:
 
-            # We create a dataset. Each dataArray in the dataset containns fluxes associated with a specific estuary on every point of the TOPAZ grid (this way we can easily modify fluxes for one estuary)
-            self.ds_topaz_river_flux=xr.Dataset(coords={"longitude":depth_grid.lon.data,"latitude":depth_grid.lat.data})
             Estuaries_index_list=self.df_dis_Estuary.index
 
             self.ds_topaz_ocean_weights=xr.Dataset(coords={"longitude":np.arange(0,jdm,1),"latitude":np.arange(0,idm,1), "Estuary_index":self.df_dis_Estuary.index})
@@ -410,14 +405,18 @@ class GloFAS_grid:
 
         outside_rradius=np.where(dist_to_land>rradius)
 
-        for i in Estuaries_index_list:
+        n_estuaries = len(Estuaries_index_list)
+        land_mask_2d = depth_grid.depth.mask.reshape((jdm, idm))
 
-            river_flux = depth_grid.depth.data * 0
+        # Collect cleaned (pre-smooth) weights for all estuaries, then batch-smooth
+        cleaned_weights = np.zeros((jdm * idm, n_estuaries))
+
+        for loop_idx, i in enumerate(Estuaries_index_list):
+
             mini,minj=np.unravel_index(self.df_dis_Estuary['idx_glofas_on_topaz'].loc[i],(jdm,idm))
 
             pos_estuary=transform_coordinates((self.df_dis_Estuary['longitude_glofas_on_topaz'].loc[i],
                                                self.df_dis_Estuary['latitude_glofas_on_topaz'].loc[i]))
-
 
             x_estuary,y_estuary,z_estuary=pos_estuary[:,0],pos_estuary[:,1],pos_estuary[:,2]
 
@@ -425,10 +424,8 @@ class GloFAS_grid:
 
             dist_to_estuary=np.ma.masked_array(dist_to_estuary,mask=depth_grid.depth.mask)
 
-
             #assign weight to ocean points based on distance to estuary
             ocean_weight=np.zeros_like(dist_to_estuary.data)
-
 
             outside_alongshore=np.where(dist_to_estuary>alongshoreradius)
             ocean_weight[~dist_to_estuary.mask]=np.exp(-dist_to_estuary[~dist_to_estuary.mask]/alongshoreradius)
@@ -437,65 +434,48 @@ class GloFAS_grid:
             #Assign extra weight based on distance to shore
             ocean_weight[~dist_to_estuary.mask]*=np.exp(-2*dist_to_land[~dist_to_estuary.mask]/rradius)
             ocean_weight[outside_rradius] *= 0
-            #
+
             # Correct shore distance weight
             land_area = closest_land[mini, minj] #Find label of land area closest to the estuary
             other_lands=np.where(closest_land.flatten()!=land_area) #Find points that have different closest land area
             ocean_weight[other_lands]*=0 #If points have different closest land area than estuary, then they have no weight
 
-
-
-            #Remove isolated points
-            #For every ocean point with weight, we try to see if there are land points between this point and the estuary
+            #Remove isolated points using Numba Just In Time method
             weight_mask=np.where(ocean_weight!=0)
-            #print("Start cleaning process for river ",i)
-
-            #We do cleaning process using Numba Just In Time method to accelerate it
             if Propagation_cleaning_step:
                 ocean_weight_copy=copy.deepcopy(ocean_weight)
                 ocean_weight=cleaning_discharge(ocean_weight_copy,weight_mask,mini,minj,idm,jdm,
-                                                depth_grid.depth.mask.reshape((jdm, idm)))
+                                                land_mask_2d)
             else:
                 print('skip river plume cleaning')
 
-            #Add smoothing step to avoid discontinuities:
-            ocean_weight_grid=np.reshape(ocean_weight,(jdm,idm))
-            smoothed_ocean_weight = gaussian_filter(ocean_weight_grid, sigma=3)
+            cleaned_weights[:, loop_idx] = ocean_weight
 
-            smoothed_ocean_weight[depth_grid.depth.mask.reshape((jdm, idm))]=0 #delete weights on land points
+        # Apply Gaussian smoothing to all estuaries in one call (sigma=0 on estuary axis = no cross-estuary mixing)
+        smoothed_3d = gaussian_filter(cleaned_weights.reshape((jdm, idm, n_estuaries)), sigma=(3, 3, 0))
+        smoothed_3d[land_mask_2d] = 0  # zero land for all estuaries at once
 
-            ocean_weight=smoothed_ocean_weight.flatten() #And back to flat array
-            
-            #Normalize the weights:
-            sum_weight=np.nansum(ocean_weight)
-            ocean_weight=ocean_weight/sum_weight
+        # Normalize each estuary's weights
+        sum_weights = smoothed_3d.sum(axis=(0, 1))  # (n_estuaries,)
+        sum_weights = np.where(sum_weights == 0, 1.0, sum_weights)
+        normalized_3d = smoothed_3d / sum_weights[np.newaxis, np.newaxis, :]
 
-            estuary_flux=self.df_dis_Estuary['dis24'].loc[i]*ocean_weight
-            river_flux+=estuary_flux #We add it to the total river flux
+        # Store normalized weights for lazy-mode reuse
+        self.ds_topaz_ocean_weights['ocean_weights'].data[:] = normalized_3d
 
-            # River flux grid for this estuary
-            self.ds_topaz_river_flux['River_flux_estuary_'+str(i)]=(["longitude"],river_flux)
+        # Compute total river flux via matrix multiply (same pattern as lazy mode)
+        dis_array = self.df_dis_Estuary['dis24'].to_numpy()
+        self.river_flux_TOPAZ = normalized_3d.reshape(-1, n_estuaries) @ dis_array
 
-            #We also save the ocean weight grid for this particular estuary:
-            self.ds_topaz_ocean_weights['ocean_weights'].loc[dict(Estuary_index=i)]=ocean_weight.reshape((jdm,idm))
-
-            # print("5:", time.time())
-
-            #We check that the sum of propagated flux is equal to estuary discahrge
-            if np.sqrt((np.nansum(estuary_flux)-self.df_dis_Estuary['dis24'].loc[i])**2)>1:
+        # Check per-estuary flux conservation
+        for loop_idx, i in enumerate(Estuaries_index_list):
+            estuary_flux = dis_array[loop_idx] * normalized_3d[:, :, loop_idx].flatten()
+            if np.sqrt((np.nansum(estuary_flux)-dis_array[loop_idx])**2)>1:
                 warnings.warn('Fluxes do not add up for river at position:'+
                       str(self.df_dis_Estuary['longitude_glofas_on_topaz'].loc[i])+','+str(self.df_dis_Estuary['latitude_glofas_on_topaz'].loc[i]))
-                print(np.nansum(estuary_flux),'!=',self.df_dis_Estuary['dis24'].loc[i])
-
+                print(np.nansum(estuary_flux),'!=',dis_array[loop_idx])
             else:
-#                print("river {river_number},  {Topaz_lon:.3f}, {Topaz_lat:.3f} : flux {river_flux:.3f} \n Sum of propagated flux={sum_prop_flux:.3f} with max local={max_prop_flux:.3f}".format(river_number=str(i), river_flux=self.df_dis_Estuary['dis24'].loc[i], sum_prop_flux=np.nansum(estuary_flux),max_prop_flux=np.nanmax(estuary_flux),Topaz_lon=self.df_dis_Estuary['longitude_glofas_on_topaz'].loc[i], Topaz_lat=self.df_dis_Estuary['latitude_glofas_on_topaz'].loc[i]))
-                print("river {river_number},  {Topaz_lon:.3f}, {Topaz_lat:.3f} : flux {river_flux:.3f} ".format(river_number=str(i), river_flux=self.df_dis_Estuary['dis24'].loc[i], Topaz_lon=self.df_dis_Estuary['longitude_glofas_on_topaz'].loc[i], Topaz_lat=self.df_dis_Estuary['latitude_glofas_on_topaz'].loc[i]))
-
-
-        #We know sum the fluxes of each estuary to obtain final grid with flux on every cell
-        self.river_flux_TOPAZ=depth_grid.depth.data*0
-        for data_vars in self.ds_topaz_river_flux.data_vars:
-            self.river_flux_TOPAZ+=self.ds_topaz_river_flux[data_vars].data
+                print("river {river_number},  {Topaz_lon:.3f}, {Topaz_lat:.3f} : flux {river_flux:.3f} ".format(river_number=str(i), river_flux=dis_array[loop_idx], Topaz_lon=self.df_dis_Estuary['longitude_glofas_on_topaz'].loc[i], Topaz_lat=self.df_dis_Estuary['latitude_glofas_on_topaz'].loc[i]))
 
         print('Total propagation time:', time.time()-start_time)
         #35s with no Numba for ocean_weight computation and Numba for cleaning process
@@ -512,7 +492,6 @@ class GloFAS_grid:
         :param depth_grid: Topaz depth grid [Agrid]
         :param input_grids: Grids object containing (among other things) the ocean weights for each estuary [Grids]
         """
-        # We create a dataset. Each dataArray in the dataset containns fluxes associated with a specific estuary on every point of the TOPAZ grid (this way we can easily modify fluxes for one estuary)
         self.ds_topaz_river_flux = xr.Dataset(
             coords={"longitude": depth_grid.lon.data, "latitude": depth_grid.lat.data})
 

--- a/bin/river-topaz/scripts/GloFAS/abfile.py
+++ b/bin/river-topaz/scripts/GloFAS/abfile.py
@@ -118,8 +118,6 @@ class AFile(object) :
          hmin=h_stored[I].min()
          J=numpy.where(mask.flatten())
          w[J] = self._spval
-         print("DEBUG writerecord: mask=True, n_ocean=%d, n_land=%d, hmin=%g, hmax=%g" % (
-               len(I[0]), len(J[0]), hmin, hmax))
         # print "writerecord w mask:",numpy.count_nonzero(mask),mask.size
         # print "writerecord w mask:",hmin,hmax,w[0:self._idm*self._jdm].min(),w[0:self._idm*self._jdm].max()
       else :

--- a/bin/river-topaz/scripts/GloFAS/abfile.py
+++ b/bin/river-topaz/scripts/GloFAS/abfile.py
@@ -105,23 +105,25 @@ class AFile(object) :
       logger.debug("zaiowr_a h shape = %s, w.size=%d"%(h.shape,w.size,))
       # Calc min and mask
       #print("mask boolean:",self._mask)
+      if self._real4 :
+         struct_fmt="f"
+         h_stored = h.astype(numpy.float32)
+      else :
+         struct_fmt="d"
+         h_stored = h.astype(numpy.float64)
+
       if self._mask :
          I=numpy.where(mask!=True)
-         hmax=h[I].max()
-         hmin=h[I].min()
+         hmax=h_stored[I].max()
+         hmin=h_stored[I].min()
          J=numpy.where(mask.flatten())
          w[J] = self._spval
         # print "writerecord w mask:",numpy.count_nonzero(mask),mask.size
         # print "writerecord w mask:",hmin,hmax,w[0:self._idm*self._jdm].min(),w[0:self._idm*self._jdm].max()
       else :
-         hmax=h.max()
-         hmin=h.min()
+         hmax=h_stored.max()
+         hmin=h_stored.min()
          #print "writerecord wo mask:",hmin,hmax
-
-      if self._real4 :
-         struct_fmt="f"
-      else :
-         struct_fmt="d"
 
       # 1) Use struct
       #binpack=struct.pack("%s%d%s"%(self._endian_structfmt,w.size,struct_fmt),*w[:])

--- a/bin/river-topaz/scripts/GloFAS/abfile.py
+++ b/bin/river-topaz/scripts/GloFAS/abfile.py
@@ -118,6 +118,8 @@ class AFile(object) :
          hmin=h_stored[I].min()
          J=numpy.where(mask.flatten())
          w[J] = self._spval
+         print("DEBUG writerecord: mask=True, n_ocean=%d, n_land=%d, hmin=%g, hmax=%g" % (
+               len(I[0]), len(J[0]), hmin, hmax))
         # print "writerecord w mask:",numpy.count_nonzero(mask),mask.size
         # print "writerecord w mask:",hmin,hmax,w[0:self._idm*self._jdm].min(),w[0:self._idm*self._jdm].max()
       else :

--- a/bin/river-topaz/scripts/GloFAS/compute_discharge_NoUI.py
+++ b/bin/river-topaz/scripts/GloFAS/compute_discharge_NoUI.py
@@ -6,15 +6,6 @@ GloFASdata_path='/cluster/projects/nn9481k/GloFAS_data/TOPAZrunoff_data'
 if GloFASdata_path not in sys.path:
    sys.path.append(GloFASdata_path)
 
-#------------------------FILES (remember to check the paths)------------------------------------------
-
-#Grid file .a
-topaz_grid_file=GloFASdata_path+'/TOPAZ5/regional.grid.a'
-
-#Depth file .a
-#topaz_depth_file=GloFASdata_path+'/TOPAZ5/depth_TP5a0.06_08.a'
-topaz_depth_file=GloFASdata_path+'/TOPAZ5/depth_TP5a0.06_05.a'
-
 #ldd file .nc
 ldd_file=GloFASdata_path+'/river/auxiliary_files__glofas_v4_0/ldd_glofas_v4_0.nc'
 
@@ -57,7 +48,7 @@ Region={'Arctic':[-180,50,180,90], 'Russia':[40,50,180,90], 'Greenland':[-70,55,
 
 #--------------------------------Building grids-------------------------------------------
 
-def compute_discharge_noUI(river_data,input_grids=None,lazy_mode=False,climatology=False,month=1,correct_GloFAS=True,Edit_estuaries=False,Propagation_cleaning_step=True,rradius = 80000,alongshoreradius = 200000):
+def compute_discharge_noUI(river_data,topaz_grid_file,topaz_depth_file,input_grids=None,lazy_mode=False,climatology=False,month=1,correct_GloFAS=True,Edit_estuaries=False,Propagation_cleaning_step=True,rradius = 80000,alongshoreradius = 200000):
     
     print("-----Parameters-----"+"\n"+"Correct GloFAS:"+ str(correct_GloFAS)+"\n"+ "Edit estuary:"+ str(Edit_estuaries)+"\n"+"Cleaning step in propagation:"+str(Propagation_cleaning_step)+"\n"+'rradius='+str(rradius)+"\n"+'alongshoreradius='+str(alongshoreradius)+"\n"+"---------------------------")
 

--- a/bin/river-topaz/scripts/GloFAS/hycom_river_hifre.py
+++ b/bin/river-topaz/scripts/GloFAS/hycom_river_hifre.py
@@ -89,6 +89,9 @@ def create_river_forcing(input_dataset,start_date,end_date,dt=.25):
                 cline2="river forcing (m/s)")
 
             land_mask = grids.topaz_depth_grid.depth.mask.reshape((jdm, idm))
+            print("DEBUG land_mask: shape=%s dtype=%s n_land=%d n_ocean=%d" % (
+                  land_mask.shape, land_mask.dtype,
+                  int(land_mask.sum()), int(land_mask.size - land_mask.sum())))
 
             input_grids=grids #The day one grids will be used for the other days
 

--- a/bin/river-topaz/scripts/GloFAS/hycom_river_hifre.py
+++ b/bin/river-topaz/scripts/GloFAS/hycom_river_hifre.py
@@ -84,9 +84,11 @@ def create_river_forcing(input_dataset,start_date,end_date,dt=.25):
                foutfile=output_path+"riverh_{start}_{end}_{dtt}h".format(start=start_date[:10],end=end_date[:10],dtt=dt*24)
             else:
                foutfile=output_path+"riverh_{start}_{end}_{dtt}d".format(start=start_date[:10],end=end_date[:10],dtt=dt)
-            ffile = abfile.ABFileRiverForcing(foutfile, "w",idm=idm, jdm=jdm,
+            ffile = abfile.ABFileRiverForcing(foutfile, "w", mask=True, idm=idm, jdm=jdm,
                 cline1="GloFAS v4.0",
                 cline2="river forcing (m/s)")
+
+            land_mask = grids.topaz_depth_grid.depth.mask.reshape((jdm, idm))
 
             input_grids=grids #The day one grids will be used for the other days
 
@@ -138,14 +140,14 @@ def create_river_forcing(input_dataset,start_date,end_date,dt=.25):
 
             for dtime in np.arange(date_as_Julian_day(value)-1,date_as_Julian_day(value),dt):
                 ffile.write_field(river_forcing['river_flux'].loc[dict(dtime1=dtime)].data*conv,
-                                river_forcing['river_flux'].loc[dict(dtime1=dtime)].data*conv,
+                                land_mask,
                                 'rivers', dtime, dt)
 
         #finally we write last day in the file
         if date_as_Julian_day(value)==end_date_as_day.days:
             period_in_hours = 24 * dt  # For conversion
             ffile.write_field(river_forcing['river_flux'].loc[dict(dtime1=end_date_as_day.days)].data * conv,
-                                             river_forcing['river_flux'].loc[dict(dtime1=end_date_as_day.days)].data * conv,
+                                             land_mask,
                                             'rivers', end_date_as_day.days, dt)
 
     ffile.close()

--- a/bin/river-topaz/scripts/GloFAS/hycom_river_hifre.py
+++ b/bin/river-topaz/scripts/GloFAS/hycom_river_hifre.py
@@ -100,7 +100,7 @@ def create_river_forcing(input_dataset,start_date,end_date,topaz_grid_file,topaz
 
  
         N=int(1//dt) #new dim size
-        river_flux_topaz_extended=np.stack([river_flux_topaz] * N, axis=2)
+        river_flux_topaz_extended=np.repeat(river_flux_topaz[:, :, np.newaxis], N, axis=2)
 
 
         # Convert dtime1 slice to indices

--- a/bin/river-topaz/scripts/GloFAS/hycom_river_hifre.py
+++ b/bin/river-topaz/scripts/GloFAS/hycom_river_hifre.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import argparse
+import os
 import sys
 import numpy as np
 import xarray as xr
@@ -25,7 +26,7 @@ logger.propagate=False # Dont propagate to parent in hierarchy (determined by ".
 def date_as_Julian_day(date):
     return (pd.Timestamp(date)-pd.Timestamp(year=1900, month=12, day=31)).days
 
-def create_river_forcing(input_dataset,start_date,end_date,dt=.25):
+def create_river_forcing(input_dataset,start_date,end_date,topaz_grid_file,topaz_depth_file,dt=.25):
     """
     Creates river forcing [ab] files with dt period (6 hourly if dt=0.25) from start_date to end_date (included)
     :param input_dataset: Name of the dataset to be used (NetCDF file)
@@ -63,7 +64,8 @@ def create_river_forcing(input_dataset,start_date,end_date,dt=.25):
         correct_GloFAS=(value.astype('datetime64[Y]').astype(int)+1970>=2001) & Apply_GloFAS_correction #correction starts in 2001
         
 
-        grids = compute_discharge_noUI(river_data=daily_river_discharge, lazy_mode=lazy_mode,input_grids=input_grids,correct_GloFAS=correct_GloFAS,Edit_estuaries=Edit_estuaries,Propagation_cleaning_step=Propagation_cleaning_step,
+        grids = compute_discharge_noUI(river_data=daily_river_discharge,topaz_grid_file=topaz_grid_file,topaz_depth_file=topaz_depth_file,
+                                       lazy_mode=lazy_mode,input_grids=input_grids,correct_GloFAS=correct_GloFAS,Edit_estuaries=Edit_estuaries,Propagation_cleaning_step=Propagation_cleaning_step,
                                        rradius = rradius ,alongshoreradius = alongshoreradius)
 
         day_cntr+=1
@@ -168,9 +170,10 @@ if __name__ == "__main__" :
           setattr(args, self.dest, tmp)
 
    parser = argparse.ArgumentParser(description='Prepare HYCOM forcing files from a set of input files')
-   parser.add_argument('start_time', action=DateTimeParseAction, help='Start time in UTC zone. Format = YYYY-mm-dd<THH:MM:SS>')   
-   parser.add_argument('end_time',   action=DateTimeParseAction, help='Stop  time in UTC zone. Format = YYYY-mm-dd<THH:MM:SS>')
+   parser.add_argument('start_time',    action=DateTimeParseAction, help='Start time in UTC zone. Format = YYYY-mm-dd<THH:MM:SS>')
+   parser.add_argument('end_time',      action=DateTimeParseAction, help='Stop  time in UTC zone. Format = YYYY-mm-dd<THH:MM:SS>')
    parser.add_argument('Outfile_drt',   type=str, help='directory to save the output files')
+   parser.add_argument('depth_file',    type=str, help='path to the HYCOM depth .a file for this grid configuration')
 
    args = parser.parse_args()
 
@@ -192,8 +195,11 @@ if __name__ == "__main__" :
    GloFASdata_path='/cluster/projects/nn9481k/GloFAS_data/TOPAZrunoff_data'
    if GloFASdata_path not in sys.path:
        sys.path.append(GloFASdata_path)
-   input_dataset=GloFASdata_path+'/../data_v40/data_all_year.nc' # path to netcdf file 
-                                                                 #containing raw GloFAS data 
+   input_dataset=GloFASdata_path+'/../data_v40/data_all_year.nc' # path to netcdf file
+                                                                 #containing raw GloFAS data
+
+   topaz_depth_file=args.depth_file
+   topaz_grid_file =os.path.join(os.path.dirname(topaz_depth_file), 'regional.grid.a')
 
    Apply_GloFAS_correction=True #True to Apply GloFAS correction starting from 2001
 
@@ -210,7 +216,8 @@ if __name__ == "__main__" :
 #---------------------------------------------------------------------------------------------
 
    river_forcing=create_river_forcing(input_dataset=input_dataset,
-                    start_date=start_date,end_date=end_date)
+                    start_date=start_date,end_date=end_date,
+                    topaz_grid_file=topaz_grid_file,topaz_depth_file=topaz_depth_file)
    river_netcdf=river_forcing['river_flux'].transpose("dtime1","longitude","latitude")
    river_netcdf.to_netcdf('{wrkdrt}/riverh_{start}_{end}.nc'.format(wrkdrt=output_path,
                     start=start_date[:10],end=end_date[:10]),unlimited_dims='dtime1')

--- a/bin/river-topaz/scripts/GloFAS/hycom_river_hifre.py
+++ b/bin/river-topaz/scripts/GloFAS/hycom_river_hifre.py
@@ -56,13 +56,18 @@ def create_river_forcing(input_dataset,start_date,end_date,topaz_grid_file,topaz
     input_grids=None
     day_cntr=0
 
+    import time as _time
+    t_total_start = _time.time()
 
     for value in data.time.values:
+
+        t_day_start = _time.time()
+        date_str = str(value)[:10]
 
         daily_river_discharge=data.sel(time=value)
 
         correct_GloFAS=(value.astype('datetime64[Y]').astype(int)+1970>=2001) & Apply_GloFAS_correction #correction starts in 2001
-        
+
 
         grids = compute_discharge_noUI(river_data=daily_river_discharge,topaz_grid_file=topaz_grid_file,topaz_depth_file=topaz_depth_file,
                                        lazy_mode=lazy_mode,input_grids=input_grids,correct_GloFAS=correct_GloFAS,Edit_estuaries=Edit_estuaries,Propagation_cleaning_step=Propagation_cleaning_step,
@@ -152,7 +157,14 @@ def create_river_forcing(input_dataset,start_date,end_date,topaz_grid_file,topaz
                                              land_mask,
                                             'rivers', end_date_as_day.days, dt)
 
+        print("Day %s done in %.1f s  (total elapsed: %.1f s)" % (
+              date_str, _time.time()-t_day_start, _time.time()-t_total_start))
+
     ffile.close()
+
+    n_days = day_cntr
+    t_total = _time.time() - t_total_start
+    print("\nFinished: %d days processed in %.1f s  (%.1f s/day)" % (n_days, t_total, t_total/max(n_days,1)))
 
     return river_forcing
 

--- a/bin/river-topaz/scripts/GloFAS/hycom_river_hifre.py
+++ b/bin/river-topaz/scripts/GloFAS/hycom_river_hifre.py
@@ -91,9 +91,6 @@ def create_river_forcing(input_dataset,start_date,end_date,topaz_grid_file,topaz
                 cline2="river forcing (m/s)")
 
             land_mask = grids.topaz_depth_grid.depth.mask.reshape((jdm, idm))
-            print("DEBUG land_mask: shape=%s dtype=%s n_land=%d n_ocean=%d" % (
-                  land_mask.shape, land_mask.dtype,
-                  int(land_mask.sum()), int(land_mask.size - land_mask.sum())))
 
             input_grids=grids #The day one grids will be used for the other days
 

--- a/bin/river_synoptic.sh
+++ b/bin/river_synoptic.sh
@@ -33,7 +33,7 @@ source ${BINDIR}/common_functions.sh || { echo "Could not source ${BINDIR}/commo
 source ${BASEDIR}/REGION.src || { echo "Could not source ${BASEDIR}/REGION.src" ; exit 1 ; }
 source ./EXPT.src || { echo "Could not source ./EXPT.src" ; exit 1 ; }
 
-D=$BASEDIR/force/rivers/$E/
+D=$BASEDIR/force/rivers/$E
 S=$D/SCRATCH
 [ ! -d $D ] && mkdir -p $D
 [ ! -d $S ] && mkdir -p $S
@@ -43,12 +43,19 @@ cd       $S || { echo " Could not descend scratch dir $S" ; exit 1;}
 # --- Input. Function in common_functions.sh
 #
 #copy_setup_files $S
-
+# check the right depth files:
+if [ -s ${BASEDIR}/topo/regional.depth.a -a -s ${BASEDIR}/topo/regional.depth.b ]; then
+   depthfile=${BASEDIR}/topo/regional.depth.a
+else
+   #depthfile=$(ls ${BASEDIR}/topo/depth_*.a 2>/dev/null | head -1)
+   depthfile=${BASEDIR}/topo/depth_${R}_${T}.a
+fi
+[ -z "$depthfile" ] && { echo "Could not find depth file ${depthfile} in ${BASEDIR}/topo/" ; exit 1 ; }
 
 ml load matplotlib/3.5.2-foss-2022a
 cd ${BINDIR}/river-topaz/scripts/GloFAS
-depthfile=$(ls ${BASEDIR}/topo/depth_*.a 2>/dev/null | head -1)
-[ -z "$depthfile" ] && { echo "Could not find depth file in ${BASEDIR}/topo/" ; exit 1 ; }
+echo "python ${BINDIR}/river-topaz/scripts/GloFAS/hycom_river_hifre.py $start $stop $S/ $depthfile"
+
 cmd="python ${BINDIR}/river-topaz/scripts/GloFAS/hycom_river_hifre.py $start $stop $S/ $depthfile"
 eval $cmd   ||  { echo "Error running $cmd " ; exit 1 ; }
 

--- a/bin/river_synoptic.sh
+++ b/bin/river_synoptic.sh
@@ -47,8 +47,8 @@ cd       $S || { echo " Could not descend scratch dir $S" ; exit 1;}
 
 ml load matplotlib/3.5.2-foss-2022a
 cd ${BINDIR}/river-topaz/scripts/GloFAS
-depthfile=$(ls ${BASEDIR}/../topo/depth_*.a 2>/dev/null | head -1)
-[ -z "$depthfile" ] && { echo "Could not find depth file in ${BASEDIR}/../topo/" ; exit 1 ; }
+depthfile=$(ls ${BASEDIR}/topo/depth_*.a 2>/dev/null | head -1)
+[ -z "$depthfile" ] && { echo "Could not find depth file in ${BASEDIR}/topo/" ; exit 1 ; }
 cmd="python ${BINDIR}/river-topaz/scripts/GloFAS/hycom_river_hifre.py $start $stop $S/ $depthfile"
 eval $cmd   ||  { echo "Error running $cmd " ; exit 1 ; }
 

--- a/bin/river_synoptic.sh
+++ b/bin/river_synoptic.sh
@@ -47,7 +47,9 @@ cd       $S || { echo " Could not descend scratch dir $S" ; exit 1;}
 
 ml load matplotlib/3.5.2-foss-2022a
 cd ${BINDIR}/river-topaz/scripts/GloFAS
-cmd="python ${BINDIR}/river-topaz/scripts/GloFAS/hycom_river_hifre.py $start $stop $S/"
+depthfile=$(ls ${BASEDIR}/../topo/depth_*.a 2>/dev/null | head -1)
+[ -z "$depthfile" ] && { echo "Could not find depth file in ${BASEDIR}/../topo/" ; exit 1 ; }
+cmd="python ${BINDIR}/river-topaz/scripts/GloFAS/hycom_river_hifre.py $start $stop $S/ $depthfile"
 eval $cmd   ||  { echo "Error running $cmd " ; exit 1 ; }
 
 # The nersc river forcing is region-independent 

--- a/bin/river_synoptic.sh
+++ b/bin/river_synoptic.sh
@@ -54,6 +54,12 @@ fi
 
 ml load matplotlib/3.5.2-foss-2022a
 cd ${BINDIR}/river-topaz/scripts/GloFAS
+
+depthfile=${BASEDIR}/topo/regional.depth.a
+[ ! -e "$depthfile" ] && { echo "Could not find $depthfile" ; exit 1 ; }
+
+[ -z "$depthfile" ] && { echo "Could not find depth file in ${BASEDIR}/topo/" ; exit 1 ; }
+
 echo "python ${BINDIR}/river-topaz/scripts/GloFAS/hycom_river_hifre.py $start $stop $S/ $depthfile"
 
 cmd="python ${BINDIR}/river-topaz/scripts/GloFAS/hycom_river_hifre.py $start $stop $S/ $depthfile"


### PR DESCRIPTION
 Title: Fix river forcing .a/.b min/max mismatch and performance improvements

  Description:

  Bug fixes

  - .a/.b min/max mismatch (abfile.py): min/max were computed from float64 data but the .a file stores float32. Fixed by computing min/max from the float32-cast data.
  - Land cell values inflating .b max (hycom_river_hifre.py): floating-point residuals from Gaussian smoothing left tiny nonzero values at land cells, inflating the .b max. HYCOM applies its own land mask when reading .a, causing the mismatch. Fixed by passing the TOPAZ depth mask to ABFileRiverForcing (mask=True) so min/max are computed over ocean cells only.

  Configurability

  - topaz_grid_file and topaz_depth_file were hard-coded for the TOPAZ5 configuration. Now, the grid file is derived from the same directory. river_synoptic.sh auto-detects the depth file from
  ${BASEDIR}/topo/.
  
  Performance

  - Batch Gaussian filter: replaced ~N per-estuary calls with one call on a (jdm, idm, n_estuaries) array using sigma=(3,3,0).
  - Removed per-estuary xarray Dataset; river flux now accumulated via matrix multiply.
  - Cached Russian river correction indices (computed once instead of every day).
  - np.repeat instead of np.stack([arr]*N).
  - Per-day and total timing output added.
