### PR TITLE
Pass simulation time to FABM in `prepare_inputs` call

### DIFF
--- a/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_hycom_fabm.F90
+++ b/hycom/RELO/HYCOM_NERSC_src_v2.3/mod_hycom_fabm.F90
@@ -742,7 +742,7 @@ call check_finite("AFTER VERTICAL", n)
     end do
 #endif
 
-call fabm_model%prepare_inputs
+call fabm_model%prepare_inputs(real(nstep))
 !      do k=1,kk
 !        do j=1,jj
 !          call fabm_get_light_extinction(fabm_model, 1, ii, j, k, extinction)


### PR DESCRIPTION
### Issue

In the v2.3 HYCOM source (`HYCOM_NERSC_src_v2.3/mod_hycom_fabm.F90`), `fabm_model%prepare_inputs` was called without the time argument, leaving FABM's internal `has_time` flag as `.false.`. This caused the time-averaging calculator used by the GOTM light module (86400 s daily mean PAR) to abort on the first timestep with "host did not provide time information", crashing all MPI tasks. 

### Fix

The fix passes the current step count `nstep` as the time argument.