### PR TITLE
Add MSCPROGS to PATH

### DIFF
--- a/input/REGION.src
+++ b/input/REGION.src
@@ -36,7 +36,7 @@ done
 
 
 # Update path
-export PATH=$BINDIR/:$PATH
+export PATH=$BINDIR/:$MSCPROGS/bin:$MSCPROGS/bin_setup:$PATH
 export Sysdir_nn2993k=/cluster/projects/nn2993k
 export Sysdir_nn9481k=/cluster/projects/nn9481k
 


### PR DESCRIPTION
Adds `$MSCPROGS/bin` and `$MSCPROGS/bin_setup` to `PATH` in the `input/REGION.src` template. Since each run directory copies this template and sources it before running the model, the `MSCPROGS` executables are on `PATH` automatically, and no manual export or `.bashrc` entry is needed.