### PR TITLE
revise river_synoptic.sh to read regional.depth.a as the depth file

### DIFF
--- a/bin/river_synoptic.sh
+++ b/bin/river_synoptic.sh
@@ -47,7 +47,10 @@ cd       $S || { echo " Could not descend scratch dir $S" ; exit 1;}
 
 ml load matplotlib/3.5.2-foss-2022a
 cd ${BINDIR}/river-topaz/scripts/GloFAS
-depthfile=$(ls ${BASEDIR}/topo/depth_*.a 2>/dev/null | head -1)
+
+depthfile=${BASEDIR}/topo/regional.depth.a
+[ ! -e "$depthfile" ] && { echo "Could not find $depthfile" ; exit 1 ; }
+
 [ -z "$depthfile" ] && { echo "Could not find depth file in ${BASEDIR}/topo/" ; exit 1 ; }
 cmd="python ${BINDIR}/river-topaz/scripts/GloFAS/hycom_river_hifre.py $start $stop $S/ $depthfile"
 eval $cmd   ||  { echo "Error running $cmd " ; exit 1 ; }


### PR DESCRIPTION
This PR updates bin/river_synoptic.sh to use ${BASEDIR}/topo/regional.depth.a directly as the depth file, instead of selecting the first depth_*.a file in the topo directory.