### PR TITLE
Fixed data path in docs

### DIFF
--- a/docs/forcing.md
+++ b/docs/forcing.md
@@ -51,12 +51,28 @@ For TP2 hindcast runs, restart files are archived at:
 
 For example, to start on 27 August 2016 (240th day of year):
 
+::::{dropdown} WDIR — scratch path by machine
+::::{tab-set}
+:::{tab-item} Betzy
 ```bash
 CONFIGNAME=<CONFIGNAME>   # e.g. TP2a0.10
+WDIR=$USERWORK/${CONFIGNAME}
+```
+:::
+:::{tab-item} Olivia
+```bash
+CONFIGNAME=<CONFIGNAME>   # e.g. TP2a0.10
+WDIR=/cluster/work/projects/nn2993k/$USER/${CONFIGNAME}
+```
+:::
+::::
+::::
+
+```bash
 EXPT_ID=<EXPT_ID>         # e.g. 01.0
 
-mkdir -p $WORK/${CONFIGNAME}/expt_${EXPT_ID}/data/cice
-cd $WORK/${CONFIGNAME}/expt_${EXPT_ID}/data
+mkdir -p $WDIR/expt_${EXPT_ID}/data/cice
+cd $WDIR/expt_${EXPT_ID}/data
 
 cp /nird/datalake/NS9481K/shuang/TP2_output/expt_02.6/restart/restart.2016_240_00_0000.a .
 cp /nird/datalake/NS9481K/shuang/TP2_output/expt_02.6/restart/restart.2016_240_00_0000.b .


### PR DESCRIPTION
## Description

Data directory path has been updated in the restart files section of the docs with the new file management.

## Checklist

- [X] I have updated the documentation to reflect these changes, where relevant.

  See the [contributor guide](https://nersc-hycom-cice.readthedocs.io/en/latest/contributing.html#previewing-documentation-changes-in-a-pr) for how to preview your documentation changes.

- [X] I have tested these changes, where relevant.
