### PR TITLE
WIP: Add pre-commit hooks for linting and clean code

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,13 @@
+name: lint
+
+on:
+  push:
+    branches: [develop, master]
+  pull_request:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: ^(hycom/|cice/|MSCPROGS/)
+      - id: end-of-file-fixer
+        exclude: ^(hycom/|cice/|MSCPROGS/)
+      - id: check-yaml
+      - id: check-merge-conflict
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: [--severity=warning, --shell=bash]
+        # exclude third-party Fortran build scripts
+        exclude: ^(hycom/|cice/|MSCPROGS/)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,10 @@ repos:
         args: [--severity=warning, --shell=bash]
         # exclude third-party Fortran build scripts
         exclude: ^(hycom/|cice/|MSCPROGS/)
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -57,3 +57,27 @@ To see how your changes to the documentation render, you have two options:
 - The table of contents is defined in `docs/index.rst`.
 - To add a new page, create a `.md` file in `docs/` and add its name (without
   extension) to the appropriate `toctree` block in `docs/index.rst`.
+
+## Pre-commit hooks
+
+The repository uses [pre-commit](https://pre-commit.com) to run static checks
+before each commit. The hooks check shell scripts with
+[ShellCheck](https://www.shellcheck.net/) and enforce basic file hygiene
+(trailing whitespace, end-of-file newlines, YAML syntax, merge-conflict markers).
+
+`pre-commit` is included in `environment/python.yaml`. To activate the hooks
+after setting up your environment, run once:
+
+```bash
+pre-commit install
+```
+
+After that, the checks run automatically on every `git commit`. To run them
+manually across all files:
+
+```bash
+pre-commit run --all-files
+```
+
+The same checks run in CI on every push and pull request, so they will catch
+issues even without a local install.

--- a/environment/python.yaml
+++ b/environment/python.yaml
@@ -15,5 +15,6 @@ dependencies:
   - pip
   - udunits2
   - cmocean
+  - pre-commit
   - pip:
       - cfunits


### PR DESCRIPTION
Adds .pre-commit-config.yaml with:
- shellcheck (--severity=warning) on all bin/*.sh, excluding third-party source trees (hycom/, cice/, MSCPROGS/)
- standard pre-commit-hooks (trailing whitespace, EOF, YAML, merge conflict)

Adds .github/workflows/lint.yml that runs pre-commit/action on every push and pull request, so hooks are enforced even without a local install.

To activate locally: pip install pre-commit && pre-commit install

## Description

<!-- What does this PR do, and why? -->

## Checklist

- [ ] I have updated the documentation to reflect these changes, where relevant.

  See the [contributor guide](https://nersc-hycom-cice.readthedocs.io/en/latest/contributing.html#previewing-documentation-changes-in-a-pr) for how to preview your documentation changes.

- [ ] I have tested these changes, where relevant.
