### PR TITLE
Olivia setup

### DIFF
--- a/bin/compile_model.sh
+++ b/bin/compile_model.sh
@@ -44,13 +44,14 @@ usage="
    code in $sourcedir, then pushed to the code repository
 
    Example:
-      $(basename $0) [ -u ]  [ -m mpi_library ]  compiler
+      $(basename $0) [ -u ] [ -c cluster ] [ -m mpi_library ] compiler
 
    arguments   :
-      compiler : compiler to use for. Currently supported: ifort gfortran pgi
+      compiler : compiler to use for. Currently supported: ifort ifx gfortran pgi
 
    optional arguments :
       -u              : update code in build dir from $sourcedir
+      -c cluster      : set cluster/site explicitly (overrides hostname/domain detection)
       -m mpi_library  : on some machines you need to specify what mpi library to use
 
 
@@ -65,29 +66,34 @@ usage="
 "
 
 # This will process optional arguments
-options=$(getopt -o m:u -- "$@")
+options=$(getopt -o c:m:u -- "$@")
 [ $? -eq 0 ] || {
     echo "$usage"
     echo "Error: Incorrect options provided"
     exit 1
 }
 mpilib=""
+cluster=""
 eval set -- "$options"
 while true; do
     case "$1" in
-    -m)
-       shift;
-       mpilib=$1
-        ;;
-    -u)
-       update="update"
-        ;;
-    --)
-        shift
-        break
-        ;;
-    esac
-    shift
+            -c)
+                  shift;
+                  cluster=$1
+                  ;;
+            -m)
+                  shift;
+                  mpilib=$1
+                  ;;
+            -u)
+                  update="update"
+                  ;;
+            --)
+                  shift
+                  break
+                  ;;
+      esac
+      shift
 done
 
 
@@ -96,11 +102,12 @@ if [ $# -gt 0 ] ; then
    compiler=$1
 else 
    echo "$usage"
-   echo "Error: Need to provide compiler to script, options: gfortran pgi ifort "
+   echo "Error: Need to provide compiler to script, options: gfortran pgi ifort ifx "
    exit 1
 fi
 echo "$(basename $0) : compiler=$compiler"
 echo "$(basename $0) : mpilib=$mpilib"
+echo "$(basename $0) : cluster=$cluster"
 
 # Check ARCH based on uname. Only Linux accepted 
 ARCH=$(uname -s)
@@ -121,41 +128,51 @@ unamen=$(uname -n)
 hostnamed=$(hostname -d)
 
 echo $unamen
-# Hardcoded cases - hexagon
-if [ "${unamen:5:5}" == "bullx" ] ; then
-   SITE="surfsara"
+if [ -n "${cluster}" ] ; then
+   SITE="${cluster}"
    MACROID=$ARCH.$SITE.$compiler
-
-elif [ "${unamen:0:5}" == "alvin" ] ; then
-   SITE="alvin"
-   MACROID=$ARCH.$SITE.$compiler
-
-elif [ "${unamen:0:5}" == "elvis" ] ; then
-   SITE="elvis"
-   MACROID=$ARCH.$SITE.$compiler
-elif [ "${hostnamed:0:5}" == "betzy" ] ; then
-   SITE="betzy"
-   MACROID=$ARCH.$SITE.$compiler
-elif [ "${hostnamed:0:4}" == "fram" ] ; then # fram
-   SITE="fram"
-   MACROID=$ARCH.$SITE.$compiler
-# Generic case. SITE is empty
-elif [[ "${ARCH}" == "Linux" ]] ; then
-   SITE=""
-   if [ -z "${mpilib}" ] ; then
-      echo "mpilib must be set on input running on generic linux machine (-m option)"
-      exit 4
-   fi
-   MACROID=$ARCH.$compiler.$mpilib
-
-   echo 'MACROID=' ${MACROID}
-   if [ "${mpilib}" == "fram" ]; then
-      SITE="fram"
-   fi
-
 else
-   echo "Unknown SITE. uname -n gives $unamen"
-   exit 3
+   # Hardcoded cases - hexagon
+   if [ "${unamen:5:5}" == "bullx" ] ; then
+      SITE="surfsara"
+      MACROID=$ARCH.$SITE.$compiler
+
+   elif [ "${unamen:0:5}" == "alvin" ] ; then
+      SITE="alvin"
+      MACROID=$ARCH.$SITE.$compiler
+
+   elif [ "${unamen:0:5}" == "elvis" ] ; then
+      SITE="elvis"
+      MACROID=$ARCH.$SITE.$compiler
+   elif [ "${hostnamed:0:5}" == "betzy" ] ; then
+      SITE="betzy"
+      MACROID=$ARCH.$SITE.$compiler
+   elif [ "${hostnamed:0:4}" == "fram" ] ; then # fram
+      SITE="fram"
+      MACROID=$ARCH.$SITE.$compiler
+   # Generic case. SITE is empty
+   elif [[ "${ARCH}" == "Linux" ]] ; then
+      if [ -z "${mpilib}" ] ; then
+         echo "mpilib must be set on input running on generic linux machine (-m option)"
+         exit 4
+       fi
+      if [ "${mpilib}" == "olivia" ] ; then
+         SITE="olivia"
+         MACROID=$ARCH.$SITE.$compiler
+      else
+         SITE=""
+         MACROID=$ARCH.$compiler.$mpilib
+      fi
+
+      echo 'MACROID=' ${MACROID}
+       if [ "${mpilib}" == "fram" ]; then
+          SITE="fram"
+       fi
+
+   else
+      echo "Unknown SITE. uname -n gives $unamen"
+      exit 3
+   fi
 fi
 echo "$(basename $0) : SITE=$SITE"
 echo $MACROID
@@ -180,7 +197,7 @@ elif [ "$SITE" == "fram" ] ; then
    export ESMF_MOD_DIR=${ESMF_DIR}mod/
    export ESMF_LIB_DIR=${ESMF_DIR}lib/
 
-elif [ "$SITE" == "betzy" ] ; then
+elif [ "$SITE" == "betzy" ] || [ "$SITE" == "olivia" ] ; then
    export ESMF_DIR=${EBROOTESMF}/
    export ESMF_MOD_DIR=${ESMF_DIR}mod/
    export ESMF_LIB_DIR=${ESMF_DIR}lib/
@@ -330,7 +347,11 @@ if [ ${ICEFLG} -eq 2 ] ; then
    echo $MACROID
    # 1) Compile CICE. Environment variables need to be passe to script
    cd $targetcicedir
-   env RES=gx3 GRID=${IDM}x${JDM} SITE=$SITE MACROID=$MACROID ./comp_ice.esmf
+    if [ "$SITE" == "olivia" ] ; then
+       env RES=gx3 GRID=${IDM}x${JDM} SITE=$SITE MACROID=$MACROID CC=icx ./comp_ice.esmf
+    else
+       env RES=gx3 GRID=${IDM}x${JDM} SITE=$SITE MACROID=$MACROID ./comp_ice.esmf
+    fi
    res=$?
    if [ $res -ne 0 ] ; then 
       echo

--- a/cice/Release-5.1/bld/Macros.Linux.olivia.ifx
+++ b/cice/Release-5.1/bld/Macros.Linux.olivia.ifx
@@ -1,0 +1,59 @@
+#==============================================================================
+# Makefile macros for Olivia, Linux oneAPI environment
+#==============================================================================
+
+SLIBS      :=
+ULIBS      :=
+
+CPP        := cpp
+CPPFLAGS   := -P -traditional
+CPPDEFS    := -DLINUX
+CFLAGS     := -c -O2
+ifeq ($(COMMDIR), mpi)
+   FC         := mpifort
+else
+   FC         := ifx
+endif
+FREEFLAGS  := -FR
+FFLAGS     := -traceback -g -O2 -convert big_endian -assume byterecl -real-size 64 -integer-size 32
+
+ifeq ($(THRD), yes)
+   FFLAGS  := $(FFLAGS) -qopenmp
+endif
+
+MOD_SUFFIX := mod
+LD         := $(FC)
+LDFLAGS    := $(FFLAGS) -v
+
+    CPPDEFS := $(CPPDEFS) -DNXGLOB=$(NXGLOB) -DNYGLOB=$(NYGLOB) \
+                -DBLCKX=$(BLCKX) -DBLCKY=$(BLCKY) -DMXBLCKS=$(MXBLCKS) \
+                -DNICELYR=$(NICELYR) -DNSNWLYR=$(NSNWLYR) -DNICECAT=$(NICECAT) \
+                -DTRAGE=$(TRAGE) -DTRFY=$(TRFY) -DTRLVL=$(TRLVL) -DTRPND=$(TRPND) \
+                -DTRBRI=$(TRBRI) -DNTRAERO=$(NTRAERO) -DNBGCLYR=$(NBGCLYR) \
+                -DTRBGCS=$(TRBGCS) -DNUMIN=$(NUMIN) -DNUMAX=$(NUMAX) \
+                -DNERSC_HYCOM_CICE
+    CPPDEFS := $(CPPDEFS) -DESMF_INTERFACE -DUSE_ESMF_LIB
+    CPPDEFS := $(CPPDEFS) -Dcoupled
+
+ifeq ($(DITTO), yes)
+   CPPDEFS := $(CPPDEFS) -DREPRODUCIBLE
+endif
+
+ifeq ($(BARRIERS), yes)
+   CPPDEFS := $(CPPDEFS) -Dgather_scatter_barrier
+endif
+
+ifeq ($(IO_TYPE), netcdf)
+   CPPDEFS := $(CPPDEFS) -Dncdf
+   ifdef EBROOTNETCDFMINFORTRAN
+      INCLDIR := $(INCLDIR) -I$(EBROOTNETCDFMINFORTRAN)/include
+      SLIBS   := $(SLIBS) -L$(EBROOTNETCDFMINFORTRAN)/lib -lnetcdff
+   endif
+   ifdef EBROOTNETCDF
+      INCLDIR := $(INCLDIR) -I$(EBROOTNETCDF)/include
+      SLIBS   := $(SLIBS) -L$(EBROOTNETCDF)/lib64 -lnetcdf
+   endif
+endif
+
+INCLDIR := $(INCLDIR) -I$(ESMF_DIR)include -I$(ESMF_MOD_DIR)
+SLIBS := -lesmf_fullylinked $(SLIBS) -L$(ESMF_LIB_DIR)

--- a/cice/Release-5.1/comp_ice.esmf
+++ b/cice/Release-5.1/comp_ice.esmf
@@ -134,7 +134,11 @@ if ( ! -f $MACROFILE ) then
 endif
 
 
-icc -o makdep $CBLD/makdep.c                         || exit 2
+if ($?CC) then
+  $CC -o makdep $CBLD/makdep.c                       || exit 2
+else
+  icc -o makdep $CBLD/makdep.c                       || exit 2
+endif
 
 setenv MAKECMD make
 #MAKECMD=gmake
@@ -159,4 +163,3 @@ echo $NBGCLYR = NBGCLYR, number of bio grid layers
 echo $TRBGCS  = TRBGCS,  number of BGC tracers
 
 echo $result
-

--- a/docs/compilation.md
+++ b/docs/compilation.md
@@ -31,12 +31,18 @@ MSCPROGS provides `libhycnersc.a`, a shared library used by the [MSCPROGS post-p
 
 Create a symlink for your machine and compiler, then build and install:
 
+::::{dropdown} Betzy (NRIS/Sigma2)
+
+Use the Betzy make include (`make.betzy.ifort`, which selects the `ifort` compiler):
+
 ```bash
 cd ${HOME}/NERSC-HYCOM-CICE/hycom/MSCPROGS/src/Make.Inc
 ln -sf make.betzy.ifort make.inc
 cd ${HOME}/NERSC-HYCOM-CICE/hycom/MSCPROGS/src
 gmake clean && gmake all && gmake install
 ```
+
+::::
 
 ::::{dropdown} Olivia (NRIS/Sigma2)
 

--- a/docs/compilation.md
+++ b/docs/compilation.md
@@ -17,7 +17,9 @@ See the [HPC environment](installation.md#hpc-environment) section for details.
 ::::
 
 :::{note}
-Olivia support is a work in progress. 
+Olivia support is a work in progress. The status of each step is called out below: the
+MSCPROGS build is the most complete, while HYCOM-CICE is untested and `hycom_ALL` is
+incomplete. These notes track [README.olivia](https://github.com/kvikende/NERSC-HYCOM-CICE/blob/wip-olivia/README.olivia).
 :::
 
 ## Compile MSCPROGS (libhycnersc.a)
@@ -35,6 +37,20 @@ ln -sf make.betzy.ifort make.inc
 cd ${HOME}/NERSC-HYCOM-CICE/hycom/MSCPROGS/src
 gmake clean && gmake all && gmake install
 ```
+
+::::{dropdown} Olivia (NRIS/Sigma2)
+
+Use the Olivia make include (`make.olivia.ifx`, which selects the `ifx`/`icx` compilers and
+links FFTW + MKL):
+
+```bash
+cd ${HOME}/NERSC-HYCOM-CICE/hycom/MSCPROGS/src/Make.Inc
+ln -sf make.olivia.ifx make.inc
+cd ${HOME}/NERSC-HYCOM-CICE/hycom/MSCPROGS/src
+gmake clean && gmake all && gmake install
+```
+
+::::
 
 After installation, `libhycnersc.a` is at:
 
@@ -92,6 +108,10 @@ After installation, `libfabm.a` is at:
 ${HOME}/local/fabm/hycom/lib64/libfabm.a
 ```
 
+:::{caution}
+On Olivia, BGC/FABM compilation is **untested** and is not covered by [README.olivia](https://github.com/kvikende/NERSC-HYCOM-CICE/blob/wip-olivia/README.olivia). In
+principle it would use `-DCMAKE_Fortran_COMPILER=ifx` in place of `ifort` above.
+:::
 
 ## Compile HYCOM-CICE
 
@@ -148,6 +168,45 @@ EXPT_ID=<EXPT_ID>         # e.g. 01.0
 cd ${WORK}/${CONFIGNAME}/expt_${EXPT_ID}
 bash ${HOME}/NERSC-HYCOM-CICE/bin/compile_model.sh ifort -u
 ```
+
+::::{dropdown} Olivia (NRIS/Sigma2)
+
+:::{caution}
+The Olivia HYCOM-CICE build is **untested**. The build files
+(`Linux.olivia.ifx_cice.V22`/`.V23` and `Macros.Linux.olivia.ifx`) are in place, but the
+full compile and the downstream `create_ref_case.sh` setup step have not been verified end
+to end (see the known issues below).
+:::
+
+Point the config symlink at the Olivia build files (choose `V22` or `V23`):
+
+```bash
+ln -sf Linux.olivia.ifx_cice.V23 \
+    ${HOME}/NERSC-HYCOM-CICE/hycom/RELO/config/Linux.olivia.ifx_cice
+```
+
+Compile, selecting the site explicitly with `-c olivia` (hostname/domain autodetection does
+not work on Olivia) and the `ifx` compiler:
+
+```bash
+CONFIGNAME=<CONFIGNAME>   # e.g. TP2a0.10
+EXPT_ID=<EXPT_ID>         # e.g. 01.0
+
+cd ${WORK}/${CONFIGNAME}/expt_${EXPT_ID}
+bash ${HOME}/NERSC-HYCOM-CICE/bin/compile_model.sh -c olivia -u ifx
+```
+
+`-c olivia` makes the script use the `Linux.olivia.ifx*` macros and resolve ESMF from
+`$EBROOTESMF`; for CICE it passes `CC=icx`.
+
+:::{note}
+**Known unresolved issues** (from [README.olivia](https://github.com/kvikende/NERSC-HYCOM-CICE/blob/wip-olivia/README.olivia): `create_ref_case.sh` has a `module load`
+at line 132, and `bin/ice_climatology/extract_clim_iceh.sh` has `module load` lines (87 and
+90) whose Olivia-equivalent modules are not compatible with the compilation environment.
+These need adjusting before the setup/run steps will work.
+:::
+
+::::
 
 The script manages the `build/` directory containing a per-experiment copy of the source:
 
@@ -256,3 +315,18 @@ csh ./Make_clean.com
 csh ./Make_all.com
 ```
 
+::::{dropdown} Olivia (NRIS/Sigma2)
+
+:::{caution}
+The Olivia `hycom_ALL` build is **not complete**. Set the compiler to `intelIFX` in
+`Make_all.src`:
+
+```
+setenv ARCH intelIFX
+```
+
+then run `csh ./Make_all.com`. Per [README.olivia](https://github.com/kvikende/NERSC-HYCOM-CICE/blob/wip-olivia/README.olivia), only the NetCDF routines build correctly
+so far (`csh Make_ncdf.com`); the remaining utilities are not yet ported.
+:::
+
+::::

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -151,6 +151,13 @@ Run this command at the start of each session or job script where you need the
 environment. If you only use one Python environment, you can also add it to `~/.bashrc`
 to activate it automatically.
 
+:::{tip}
+The steps above are also scripted under `environment/py-nhc/`: set `$PYLIBSPATH` in
+`py-nhc-env-post.sh`, then run `create_python_env.sh` (with the `hpc-container-wrapper`
+module loaded). It builds the container into `environment/py-nhc/py-nhc-env/`; add that
+`bin/` directory to `$PATH` to activate.
+:::
+
 ::::
 
 ### Use the environment

--- a/docs/mscprogs.md
+++ b/docs/mscprogs.md
@@ -57,6 +57,16 @@ cd $WORK/${CONFIGNAME}/expt_${EXPT_ID}/data/
 [expt_postprocess.sh](running.md#submit-a-job) copies `regional.grid.*` and `regional.depth.*` here
 automatically after each model run, so the grid files are already in place.
 
+If you plan to use `hyc2proj` or `hyc2stations`, also copy `grid.info` (conformal mapping
+parameters for the model grid). For standard configurations (TP0, TP2, TP5) it is included
+in the repository:
+
+```bash
+cp ${HOME}/NERSC-HYCOM-CICE/${CONFIGNAME}/topo/grid.info .
+```
+
+For other configurations, copy it from `$WORK/${CONFIGNAME}/topo/`.
+
 You still need to copy the relevant [input files](#input-files) into the working
 directory. Example input files are provided in `$MSCPROGS/Input/`.
 
@@ -66,6 +76,41 @@ You can also run MSCPROGS tools directly from the scratch directory
 `expt_preprocess.sh` already copies `regional.grid.*` and `regional.depth.*`
 there, so only the input files need to be copied in — the same step as above.
 :::
+
+::::{dropdown} Working with data on NIRD
+
+If the data is on NIRD (your own archived run or a collaborator's) and you do not want to write into that directory, create your own working directory and copy the grid files:
+
+```bash
+mkdir -p <workdir> && cd <workdir>
+cp /nird/path/to/expt/data/regional.grid.* .
+cp /nird/path/to/expt/data/regional.depth.* .
+cp ${HOME}/NERSC-HYCOM-CICE/<CONFIGNAME>/topo/grid.info .   # only needed for hyc2proj and hyc2stations; available in the repo for standard configs (TP0, TP2, TP5)
+```
+
+Then copy the tool-specific input files and pass the archive files as arguments — output is written to the current directory, leaving the source data untouched.
+
+NIRD access differs between machines:
+
+| | Login node | SVC node | Compute node |
+|---|---|---|---|
+| Betzy | read-write | — | not mounted |
+| Olivia | not mounted | read-write | read-only |
+
+**Copy** (not symlink) the archive files (`archm.*` / `archv.*`, both `.a` and `.b`) onto scratch before processing — the [parallel-by-year `hyc2proj` script](#batch-post-processing) *moves* files into per-year directories, which fails on a read-only source, and streaming large 3-D archives live over NIRD is slow:
+
+- **Betzy**: copy from the login node to `/cluster/work/users/$USER/postproc/<run>/`
+- **Olivia**: copy from a service (SVC) node to `/cluster/work/projects/nn2993k/$USER/postproc/<run>/`
+
+On Olivia, tools that only read archives — `m2nc`, `hycave`, `m2section` — can also read directly from NIRD inside a batch job, skipping the staging step.
+
+Move the resulting `.nc` files to `/cluster/projects/nn2993k/$USER/...` (or back to NIRD) before the 21-day scratch purge, then delete the staged archives.
+
+:::{tip}
+For a large multi-year run, stage and process one year at a time to keep the scratch footprint bounded.
+:::
+
+::::
 
 ### Typical workflow
 
@@ -96,10 +141,7 @@ Four output projections are supported:
 `hyc2proj` requires the following files in the working directory:
 
 - `regional.grid.a/.b` and `regional.depth.a/.b` — already present in `data/` and `SCRATCH/`
-- `grid.info` — conformal mapping parameters for the model grid; copy from `topo/`:
-  ```bash
-  cp $WORK/<CONFIGNAME>/topo/grid.info .
-  ```
+- `grid.info` — conformal mapping parameters for the model grid (see [Working directory](#working-directory))
 - `proj.in` — target projection and grid (see [Input files](#input-files))
 - `depthlevels.in` — vertical depth levels to interpolate to
 - an `extract.*` file — fields to extract; the tool auto-selects the file by name based on the input file type (e.g. `extract.archm` for archm files), so the name must not be changed
@@ -109,7 +151,6 @@ spline. `staircase` and `linear` options are also available (faster but lower
 quality).
 
 ```bash
-cp $WORK/<CONFIGNAME>/topo/grid.info .
 cp $MSCPROGS/Input/proj.in.regular_grid proj.in     # choose and edit a sample proj.in
 cp $MSCPROGS/Input/depthlevels.in .
 cp $MSCPROGS/Input/extract.archm .
@@ -327,38 +368,6 @@ Requires the external FES2014 C library and the GNU C compiler; see
 | `Tides_CSR` | `csr2mod_GE` | Tidal boundary forcing from CSR tidal atlas |
 | `TRIP` | `trip_*` | River forcing from the TRIP database + ERA40/ERA-i runoff |
 | `ZONAL` | `zonal`, `mosf` | Zonal averages and meridional overturning streamfunction |
-
-## Post-processing runs from NIRD
-
-NIRD access differs between machines:
-
-| | Login node | SVC node | Compute node |
-|---|---|---|---|
-| Betzy | read-write | — | not mounted |
-| Olivia | not mounted | read-write | read-only |
-
-The recommended workflow is to **copy** (not symlink) archives onto the scratch filesystem
-before processing — the [parallel-by-year `hyc2proj` script](#batch-post-processing) *moves*
-files into per-year directories, which fails on a read-only source, and streaming large
-3-D archives live over NIRD is slow.
-
-Stage the archive files (`archm.*` / `archv.*`, both `.a` and `.b`) together with the run's
-`regional.*` and `grid.info` into a scratch directory:
-
-- **Betzy**: copy from the login node to `/cluster/work/users/$USER/postproc/<run>/`
-- **Olivia**: copy from a service (SVC) node to `/cluster/work/projects/nn2993k/$USER/postproc/<run>/`
-
-Then run the post-processing tool from the staging directory. On Olivia, tools that only
-read archives — `m2nc`, `hycave`, `m2section` — can also read directly from NIRD inside a
-batch job, skipping the staging step.
-
-Move the resulting `.nc` files to `/cluster/projects/nn2993k/$USER/...` (or back to NIRD)
-before the 21-day scratch purge, then delete the staged archives.
-
-:::{tip}
-For a large multi-year run, stage and process one year at a time to keep the scratch
-footprint bounded.
-:::
 
 ## Input files
 

--- a/docs/mscprogs.md
+++ b/docs/mscprogs.md
@@ -23,8 +23,7 @@ You don't need both. See [xhycom](xhycom.md) if you'd rather work in Python.
 
 ### Environment setup
 
-Before running any MSCPROGS tool, load the HPC modules and set `$MSCPROGS`.
-See the [HPC environment](installation.md#hpc-environment) section for details.
+Before running any MSCPROGS tool, load the HPC modules and set `$MSCPROGS` and `$PATH`.
 
 ::::{dropdown} Source HPC environment — Betzy (NRIS/Sigma2)
 
@@ -33,18 +32,26 @@ See the [HPC environment](installation.md#hpc-environment) section for details.
 
 ::::
 
-```bash
-source $WORK/<CONFIGNAME>/REGION.src    # sets $MSCPROGS and other paths
+::::{dropdown} Source HPC environment — Olivia (NRIS/Sigma2)
+
+```{include} _snippets/olivia_hpc_env.md
 ```
 
-`REGION.src` also adds `$MSCPROGS/bin` and `$MSCPROGS/bin_setup` to your `PATH`, so all MSCPROGS executables are immediately available.
+::::
+
+```bash
+export MSCPROGS=${HOME}/NERSC-HYCOM-CICE/hycom/MSCPROGS
+export PATH=${MSCPROGS}/bin:${MSCPROGS}/bin_setup:${PATH}
+```
 
 ### Working directory
 
 The natural place to run MSCPROGS tools is the experiment data directory:
 
 ```bash
-cd $WORK/<CONFIGNAME>/expt_<EXPT_ID>/data/
+CONFIGNAME=<CONFIGNAME>   # e.g. TP2a0.10
+EXPT_ID=<EXPT_ID>         # e.g. 01.0
+cd $WORK/${CONFIGNAME}/expt_${EXPT_ID}/data/
 ```
 
 [expt_postprocess.sh](running.md#submit-a-job) copies `regional.grid.*` and `regional.depth.*` here

--- a/hycom/MSCPROGS/src/Make.Inc/make.olivia.ifx
+++ b/hycom/MSCPROGS/src/Make.Inc/make.olivia.ifx
@@ -1,0 +1,35 @@
+# include file for fimm, intel compilers (adapted for ifx/icx)
+CF90 = ifx
+CF77 = $(CF90)
+CC = icx
+LD = $(CF90)
+
+# CPP, used internally by compilers
+CPP = /usr/bin/cpp -P -traditional-cpp
+CPPARCH = -DIA32 -DREA8 -DMPI -DSERIA_IO -DTIMER -DIARGC -DFFTW -LAPACK
+
+# Flags for fixed/free format
+F90FLG = -free
+F77FLG = -fixed
+
+# NetCDF settings
+NETCDF_INC = -I$(EBROOTNETCDFMINFORTRAN)/include
+NETCDF_LIB = -L$(EBROOTNETCDFMINFORTRAN)/lib -lnetcdff -L$(EBROOTNETCDF)/lib64 -lnetcdf
+
+# Compiler flags - real*8 version
+FFLAGS = -g -O2 -convert big_endian -assume byterecl -r8 $(NETCDF_INC)
+CFLAGS = -O2
+
+# Compiler flags - real*4 version (Needed for NCARG routines)
+FFLAGSR4 = -g -O2 -real_size 32 -convert big_endian
+CFLAGSR4 = -O2
+
+# Linker flags
+LINKFLAGS = $(FFLAGS)
+
+# Libraries
+# Note: -qmkl is the modern successor to -lmkl for ifx
+LIBS = $(NETCDF_LIB) -lfftw3 -qmkl
+
+# Define CPP flags consistent with libs above
+CPPFLAGS = -DFFTW -DLAPACK

--- a/hycom/RELO/config/Linux.olivia.ifx_cice.V22
+++ b/hycom/RELO/config/Linux.olivia.ifx_cice.V22
@@ -1,0 +1,75 @@
+#
+# ---------------------------------------------------------------------
+# Olivia oneAPI compiler setup for HYCOM-CICE (v2.2.x)
+# ---------------------------------------------------------------------
+#
+# MACROS      DESCRIPTIONS:
+#
+# FC:         Fortran 90 compiler.
+# FCFFLAGS:   Fortran 90 compilation flags.
+# CC:         C compiler.
+# CCFLAGS:    C compilation flags.
+# CPP:        cpp preprocessor (may be implied by FC).
+# CPPFLAGS:   cpp -D macro flags.
+# LD:         Loader.
+# LDFLAGS:    Loader flags.
+# EXTRALIBS:  Extra local libraries (if any).
+#
+INCLUDES      = -I${ESMF_MOD_DIR} -I${ESMF_DIR}include -I../CICE/rundir/compile
+
+FC            = mpifort
+ifeq ($(debug), true)
+	FCFFLAGS      = -g -traceback -check bounds -convert big_endian -assume byterecl -r8
+else
+	FCFFLAGS      = -g -O2 -convert big_endian -assume byterecl -r8
+endif
+
+FCFFLAGS     := $(FCFFLAGS) $(INCLUDES)
+
+CC            = mpicc
+CCFLAGS       = -O
+
+CPP           = cpp -P
+LD            = $(FC)
+LDFLAGS       = $(FCFFLAGS) -mcmodel=medium
+
+# ENDIAN_IO         not needed due to byteswap compiler flag
+# NERSC_HYCOM_CICE  Code changes specific to our version
+CPPFLAGS      = -DIA32 -DREAL8 -DMPI -DSERIAL_IO -DNAN2003 -DTIMER -DRELO -DUSE_ESMF -DUSE_ESMF_5 -DNERSC_HYCOM_CICE
+EXTRALIBS     = -L${ESMF_LIB_DIR}/ -lesmf_fullylinked -lmkl -lnetcdff -lnetcdf -lstdc++
+
+# if you want to include ECOSMO, then you should
+# add to EXPT.src or execute in the shell the following:
+# export COMPILE_BIOMODEL="yes"
+
+ifeq ($(COMPILE_BIOMODEL), yes)
+   CPPFLAGS      += -D_FABM_ -I${HOME}/local/fabm/hycom/include
+   EXTRALIBS     += -L${HOME}/local/fabm/hycom/lib64 -lfabm
+endif
+
+#
+# --- generic make definitions
+#
+SHELL         = /bin/sh
+RM            = \rm -f
+
+#
+# rules.
+#
+
+.c.o:
+	$(CC) $(CPPFLAGS) $(CCFLAGS)  -c $*.c
+
+.f.o:
+	$(FC)             $(FCFFLAGS) -c $*.f
+
+.F.o:
+	$(FC) $(CPPFLAGS) $(FCFFLAGS) -c $*.F
+
+#======= for Fabm use these
+
+.f90.o:
+	$(FC)             $(FCFFLAGS) -c $*.f90
+
+.F90.o:
+	$(FC) $(CPPFLAGS) $(FCFFLAGS) -c $*.F90

--- a/hycom/RELO/config/Linux.olivia.ifx_cice.V23
+++ b/hycom/RELO/config/Linux.olivia.ifx_cice.V23
@@ -1,0 +1,78 @@
+#
+# ---------------------------------------------------------------------
+# Olivia oneAPI compiler setup for HYCOM-CICE (v2.3)
+# ---------------------------------------------------------------------
+#
+# MACROS      DESCRIPTIONS:
+#
+# FC:         Fortran 90 compiler.
+# FCFFLAGS:   Fortran 90 compilation flags.
+# CC:         C compiler.
+# CCFLAGS:    C compilation flags.
+# CPP:        cpp preprocessor (may be implied by FC).
+# CPPFLAGS:   cpp -D macro flags.
+# LD:         Loader.
+# LDFLAGS:    Loader flags.
+# EXTRALIBS:  Extra local libraries (if any).
+#
+INCLUDES      = -I${ESMF_MOD_DIR} -I${ESMF_DIR}include -I../CICE/rundir/compile
+
+FC            = mpifort
+ifeq ($(debug), debug)
+	FCFFLAGS      = -g -traceback -check bounds -convert big_endian -assume byterecl -r8
+else
+	FCFFLAGS      = -g -O2 -convert big_endian -assume byterecl -r8
+endif
+
+FCFFLAGS     := $(FCFFLAGS) $(INCLUDES)
+
+CC            = mpicc
+ifeq ($(debug), true)
+	CCFLAGS       = -O -g
+else
+	CCFLAGS       = -O
+endif
+CPP           = cpp -P
+LD            = $(FC)
+LDFLAGS       = $(FCFFLAGS) -mcmodel=medium
+
+# ENDIAN_IO         not needed due to byteswap compiler flag
+# NERSC_HYCOM_CICE  Code changes specific to our version
+CPPFLAGS      = -DIA32 -DREAL8 -DMPI -DSERIAL_IO -DNAN2003 -DTIMER -DRELO -DEOS_SIG0 -DEOS_7T -DNERSC_HYCOM_CICE -DNERSC_USE_ESMF -DNERSC_ATM_CPL -DNERSC_saltflux -DNERSC_T2F
+EXTRALIBS     = -L${ESMF_LIB_DIR}/ -lesmf_fullylinked -lmkl -lnetcdff -lnetcdf -lstdc++
+
+# if you want to include ECOSMO, then you should
+# add to EXPT.src or execute in the shell the following:
+# export COMPILE_BIOMODEL="yes"
+
+ifeq ($(COMPILE_BIOMODEL), yes)
+   CPPFLAGS      += -D_FABM_ -I${HOME}/local/fabm/hycom/include
+   EXTRALIBS     += -L${HOME}/local/fabm/hycom/lib64 -lfabm
+endif
+
+#
+# --- generic make definitions
+#
+SHELL         = /bin/sh
+RM            = \rm -f
+
+#
+# rules.
+#
+
+.c.o:
+	$(CC) $(CPPFLAGS) $(CCFLAGS)  -c $*.c
+
+.f.o:
+	$(FC)             $(FCFFLAGS) -c $*.f
+
+.F.o:
+	$(FC) $(CPPFLAGS) $(FCFFLAGS) -c $*.F
+
+#======= for Fabm use these
+
+.f90.o:
+	$(FC)             $(FCFFLAGS) -c $*.f90
+
+.F90.o:
+	$(FC) $(CPPFLAGS) $(FCFFLAGS) -c $*.F90


### PR DESCRIPTION
## Description

Adds build files and documentation for compiling NERSC-HYCOM-CICE on the Olivia HPC cluster (NRIS/Sigma2), using the oneAPI ifx/icx compiler toolchain.

Build files added:
- hycom/MSCPROGS/src/Make.Inc/make.olivia.ifx — MSCPROGS make include selecting ifx/icx, FFTW, and MKL
- hycom/RELO/config/Linux.olivia.ifx_cice.V22 and .V23 — HYCOM-CICE config for HYCOM v2.2 and v2.3
- cice/Release-5.1/bld/Macros.Linux.olivia.ifx — CICE macro file for Olivia

Script changes (bin/compile_model.sh):
- Adds -c cluster flag to explicitly set the site, since hostname/domain autodetection does not work on Olivia
- Adds olivia as a recognized site that resolves ESMF from $EBROOTESMF
- Passes CC=icx to comp_ice.esmf when compiling CICE on Olivia

Documentation (docs/compilation.md, docs/installation.md):
- Adds Olivia dropdowns under each compilation step (MSCPROGS, HYCOM-CICE, hycom_ALL)
- Calls out what is tested vs. untested, and lists known unresolved issues (incompatible module load lines in create_ref_case.sh and extract_clim_iceh.sh)

Status: 

- [ ] MSCPROGS build is the most complete, but still untested
- [ ] HYCOM-CICE is untested end-to-end
- [ ] hycom_ALL is incomplete (only NetCDF routines build). 

Everything is mostly based on https://github.com/kvikende/NERSC-HYCOM-CICE/blob/wip-olivia/, and have not been tested yet.

## Checklist

- [ ] I have updated the documentation to reflect these changes, where relevant.

  See the [contributor guide](https://nersc-hycom-cice.readthedocs.io/en/latest/contributing.html#previewing-documentation-changes-in-a-pr) for how to preview your documentation changes.

- [ ] I have tested these changes, where relevant.
