### PR TITLE
Clarifications for experiment setup in documentation

### DIFF
--- a/docs/compilation.md
+++ b/docs/compilation.md
@@ -123,33 +123,6 @@ ln -sf Linux.betzy.ifort_cice.V23 \
     ${HOME}/NERSC-HYCOM-CICE/hycom/RELO/config/Linux.betzy.ifort_cice
 ```
 
-:::{note}
-**If compiling with the BGC module:** ensure `ntracr` in `blkdat.input` is non-zero and
-copy the FABM configuration files and CICE namelist into the experiment directory before
-compiling:
-
-```bash
-CONFIGNAME=<CONFIGNAME>   # e.g. TP2a0.10
-EXPT_ID=<EXPT_ID>         # e.g. 01.0
-
-cd ${WORK}/${CONFIGNAME}/expt_${EXPT_ID}
-cp /nird/datalake/NS9481K/shuang/TP2_setup/exp02.6_seaclim_ref/fabm.yaml .
-cp /nird/datalake/NS9481K/shuang/TP2_setup/exp02.6_seaclim_ref/hycom_fabm.nml .
-cp /nird/datalake/NS9481K/shuang/TP2_setup/exp02.6_seaclim_ref/ice_in .
-```
-
-These files are also required to run the model. Copy them to your scratch filesystem before starting a simulation with BGC.
-
-```bash
-CONFIGNAME=<CONFIGNAME>   # e.g. TP2a0.10
-EXPT_ID=<EXPT_ID>         # e.g. 01.0
-
-cp $WORK/${CONFIGNAME}/expt_${EXPT_ID}/fabm.yaml $WDIR/expt_${EXPT_ID}/.
-cp $WORK/${CONFIGNAME}/expt_${EXPT_ID}/hycom_fabm.nml $WDIR/expt_${EXPT_ID}/.
-cp $WORK/${CONFIGNAME}/expt_${EXPT_ID}/ice_in $WDIR/expt_${EXPT_ID}/.
-```
-:::
-
 Run the compile script from the experiment directory:
 
 ```bash

--- a/docs/compilation.md
+++ b/docs/compilation.md
@@ -137,6 +137,17 @@ cp /nird/datalake/NS9481K/shuang/TP2_setup/exp02.6_seaclim_ref/fabm.yaml .
 cp /nird/datalake/NS9481K/shuang/TP2_setup/exp02.6_seaclim_ref/hycom_fabm.nml .
 cp /nird/datalake/NS9481K/shuang/TP2_setup/exp02.6_seaclim_ref/ice_in .
 ```
+
+These files are also required to run the model. Copy them to your scratch filesystem before starting a simulation with BGC.
+
+```bash
+CONFIGNAME=<CONFIGNAME>   # e.g. TP2a0.10
+EXPT_ID=<EXPT_ID>         # e.g. 01.0
+
+cp $WORK/${CONFIGNAME}/expt_${EXPT_ID}/fabm.yaml $WDIR/expt_${EXPT_ID}/.
+cp $WORK/${CONFIGNAME}/expt_${EXPT_ID}/hycom_fabm.nml $WDIR/expt_${EXPT_ID}/.
+cp $WORK/${CONFIGNAME}/expt_${EXPT_ID}/ice_in $WDIR/expt_${EXPT_ID}/.
+```
 :::
 
 Run the compile script from the experiment directory:

--- a/docs/experiment-setup.md
+++ b/docs/experiment-setup.md
@@ -497,6 +497,30 @@ Open `$WORK/<CONFIGNAME>/expt_<EXPT_ID>/EXPT.src` and update:
 | `export NMPI=` | e.g. `504` for TP2 on Betzy | Number of ocean MPI tiles |
 | `export MXBLCKS=` | e.g. `9` | Maximum ice blocks per MPI process |
 | `export COMPILE_BIOMODEL=` | `"yes"` or `"no"` | BGC coupling on/off |
+| `export S=` | machine-specific (see dropdown below) | Scratch directory |
+| `export D=` | machine-specific (see dropdown below) | Data directory |
+
+::::{dropdown} Both machines — redirect `SCRATCH` and `data` onto the scratch filesystem
+
+Keep the experiment tree (configuration and `build/`) on the non-purged `$WORK`
+(`/cluster/projects/nn2993k/$USER`), and put the two large directories — scratch and output —
+on the fast, purged scratch filesystem. Override the auto-set `S=` and `D=` lines in `EXPT.src`.
+The scratch path differs by machine:
+
+::::{tab-set}
+:::{tab-item} Betzy
+```bash
+export S=$USERWORK/<CONFIGNAME>/expt_<EXPT_ID>/SCRATCH
+export D=$USERWORK/<CONFIGNAME>/expt_<EXPT_ID>/data
+```
+:::
+:::{tab-item} Olivia
+```bash
+export S=/cluster/work/projects/nn2993k/$USER/<CONFIGNAME>/expt_<EXPT_ID>/SCRATCH
+export D=/cluster/work/projects/nn2993k/$USER/<CONFIGNAME>/expt_<EXPT_ID>/data
+```
+:::
+::::
 
 :::{note}
 For TP2, the available topography versions are: `01` (initial interpolation), `02` (adds
@@ -526,32 +550,9 @@ recommended in the error message.
 | `export SIGVER=` | Equation of state version; must be consistent with `thflag` in `blkdat.input` |
 | `export K=` | Number of layers — auto-derived from `blkdat.input`, no need to edit |
 | `export P=` | Experiment directory path — set automatically from the script location |
-| `export D=` | Permanent data directory (`P/data`) — set automatically |
-| `export S=` | Scratch directory (`P/SCRATCH`) — set automatically |
 
 ::::
 
-::::{dropdown} Both machines — redirect `SCRATCH` and `data` onto the scratch filesystem
-
-Keep the experiment tree (configuration and `build/`) on the non-purged `$WORK`
-(`/cluster/projects/nn2993k/$USER`), and put the two large directories — scratch and output —
-on the fast, purged scratch filesystem. Override the auto-set `S=` and `D=` lines in `EXPT.src`.
-The scratch path differs by machine:
-
-::::{tab-set}
-:::{tab-item} Betzy
-```bash
-export S=$USERWORK/<CONFIGNAME>/expt_<EXPT_ID>/SCRATCH
-export D=$USERWORK/<CONFIGNAME>/expt_<EXPT_ID>/data
-```
-:::
-:::{tab-item} Olivia
-```bash
-export S=/cluster/work/projects/nn2993k/$USER/<CONFIGNAME>/expt_<EXPT_ID>/SCRATCH
-export D=/cluster/work/projects/nn2993k/$USER/<CONFIGNAME>/expt_<EXPT_ID>/data
-```
-:::
-::::
 
 This is safe: `expt_preprocess.sh` only creates (`mkdir -p`) and enters (`cd`) `$S` and `$D` —
 it never deletes them — and the overrides propagate automatically when `expt_new.sh` copies

--- a/docs/experiment-setup.md
+++ b/docs/experiment-setup.md
@@ -580,5 +580,52 @@ scratch `<CONFIGNAME>/` subtree — so `relax/` must be on scratch as well, whic
 the symlinks described above ([Set up the work directory](#set-up-the-work-directory)) provide.
 :::
 
-::::
+## Files in the experiment directory
+
+To conclude the experiment setup, here is an overview of everything now present in the
+experiment directory. No action is needed — this is for reference only. Most files are
+copied from the template experiment by `expt_new.sh`; exceptions are noted.
+
+**Configuration files**
+
+| File | Purpose |
+|------|---------|
+| `blkdat.input` | Main HYCOM parameter/namelist file |
+| `EXPT.src` | Shell environment setup — defines experiment identifiers (`X`, `E`, `V`, `K`), paths to SCRATCH (`S`) and data directory (`D`), MPI task count, and other compile/run flags. Sourced by job scripts. |
+| `hycom_opt` | HYCOM optional namelist (`&hycom_nml`) — copied to the work directory by the preprocess script on each run |
+| `patch.input` | Domain decomposition tile layout for parallel HYCOM |
+
+**CICE namelist files**
+
+`cice_limits.py` reads `ice_in` as a template and rewrites it into SCRATCH with updated timing, processor count, and run type. The `.0`/`.1` variants are human-maintained references to copy to `ice_in` when switching modes.
+
+| File | Purpose |
+|------|---------|
+| `ice_in` | Active CICE namelist template — modified by `cice_limits.py` at run time |
+| `ice_in.0` | CICE namelist for cold start (`runtype=initial`, `restart=false`) |
+| `ice_in.1` | CICE namelist for continuation (`runtype=continue`, `restart=true`) |
+
+**Initial condition files**
+
+| File | Purpose |
+|------|---------|
+| `ice_initial.nc` | Initial ice state and SST/SSS for CICE cold start — staged separately from the projects filesystem (spin-up only; not needed for restart runs) |
+
+**Job scripts**
+
+| File | Purpose |
+|------|---------|
+| `srjob.sh` | Main Slurm job script for a single run segment |
+| `srjob_loop.sh` | Slurm job script for looped continuation runs |
+| `sr_job_ensemble.sh` | Slurm job script for ensemble runs |
+| `preprocess_mem.sh` | Preprocess script variant for ensemble members |
+| `sr_ensemble_post.sh` | Ensemble postprocessing script (currently empty) |
+| `create_ref_case.sh` | One-time setup script to create a new experiment from a reference case — copied from `bin/` manually (see [Climatologies and river forcing](forcing.md#climatologies-and-river-forcing)) |
+
+**Ensemble forcing**
+
+| File | Purpose |
+|------|---------|
+| `force_perturb-2.2` | Binary for generating perturbed atmospheric forcing fields for ensemble runs |
+| `infile2.in_init` | Parameters for random forcing perturbation (variances, correlation scales) — used by `force_perturb-2.2` |
 

--- a/docs/experiment-setup.md
+++ b/docs/experiment-setup.md
@@ -510,14 +510,14 @@ The scratch path differs by machine:
 ::::{tab-set}
 :::{tab-item} Betzy
 ```bash
-export S=$USERWORK/<CONFIGNAME>/expt_<EXPT_ID>/SCRATCH
-export D=$USERWORK/<CONFIGNAME>/expt_<EXPT_ID>/data
+export S=$USERWORK/<CONFIGNAME>/expt_${X}/SCRATCH
+export D=$USERWORK/<CONFIGNAME>/expt_${X}/data
 ```
 :::
 :::{tab-item} Olivia
 ```bash
-export S=/cluster/work/projects/nn2993k/$USER/<CONFIGNAME>/expt_<EXPT_ID>/SCRATCH
-export D=/cluster/work/projects/nn2993k/$USER/<CONFIGNAME>/expt_<EXPT_ID>/data
+export S=/cluster/work/projects/nn2993k/$USER/<CONFIGNAME>/expt_${X}/SCRATCH
+export D=/cluster/work/projects/nn2993k/$USER/<CONFIGNAME>/expt_${X}/data
 ```
 :::
 ::::

--- a/docs/experiment-setup.md
+++ b/docs/experiment-setup.md
@@ -522,6 +522,11 @@ export D=/cluster/work/projects/nn2993k/$USER/<CONFIGNAME>/expt_<EXPT_ID>/data
 :::
 ::::
 
+:::{important}
+`data/` is on the purged filesystem, so **archive completed output to NIRD on a rolling
+basis** (e.g. per model year as it finishes) from a service node.
+:::
+
 :::{note}
 For TP2, the available topography versions are: `01` (initial interpolation), `02` (adds
 Ob river channel), `03` (identical to `02`), `04` (blends `02`/`03` with NEMO topography
@@ -564,12 +569,6 @@ compiled executable survive the purge.
 When `D=` is overridden to a path on the scratch filesystem, `${D}/../../` resolves to the
 scratch `<CONFIGNAME>/` subtree — so `relax/` must be on scratch as well, which is exactly what
 the symlinks described above ([Set up the work directory](#set-up-the-work-directory)) provide.
-:::
-
-:::{important}
-`data/` is now on the purged filesystem, so **archive completed output to NIRD on a rolling
-basis** (e.g. per model year as it finishes) from a service node — the scratch filesystem is
-purged by file age, so early output can age out while a long run is still going.
 :::
 
 ::::

--- a/docs/experiment-setup.md
+++ b/docs/experiment-setup.md
@@ -171,9 +171,9 @@ from an existing experiment for your configuration. For TP2, reference files are
 at:
 
 - **With nesting boundary**:
-  `/nird/datalake/NS9481K/shuang/TP2_setup/exp02.6_seaclim_ref/blkdat.input`
+  `/nird/datalake/NS9481K/shuang/TP2_setup/exp02.8_seaclim_ref_new/blkdat.input_nest`
 - **With climatology boundary**:
-  `/nird/datalake/NS9481K/shuang/TP2_setup/exp02.6_seaclim_ref/blkdat.input_clim`
+  `/nird/datalake/NS9481K/shuang/TP2_setup/exp02.8_seaclim_ref_new/blkdat.input_clim`
 
 Copy it into place:
 

--- a/docs/experiment-setup.md
+++ b/docs/experiment-setup.md
@@ -164,6 +164,15 @@ values for your experiment. For TP2, the file should look like this:
 | `highfq_river` | Use time-varying (high-frequency) river forcing instead of the climatological river forcing. Requires `priver=0` in `blkdat.input`; the two options are mutually exclusive. |
 | `sssrmx_scalar` | Maximum SSS anomaly (psu) at which relaxation is still applied. Relaxation is suppressed where the model–climatology difference exceeds this value. `99.` (template default) means no cap; `.5` limits relaxation to within 0.5 psu of climatology. |
 
+Finally, copy your customized `hycom_opt` to your scratch filesystem.
+
+```bash
+CONFIGNAME=<CONFIGNAME>   # e.g. TP2a0.10
+EXPT_ID=<EXPT_ID>         # e.g. 01.0
+
+cp $WORK/${CONFIGNAME}/expt_${EXPT_ID}/hycom_opt $WDIR/expt_${EXPT_ID}/.
+```
+
 ## Configure blkdat.input
 
 `blkdat.input` controls core model parameters. The easiest starting point is to copy it

--- a/docs/experiment-setup.md
+++ b/docs/experiment-setup.md
@@ -580,6 +580,33 @@ scratch `<CONFIGNAME>/` subtree — so `relax/` must be on scratch as well, whic
 the symlinks described above ([Set up the work directory](#set-up-the-work-directory)) provide.
 :::
 
+## Additional steps when using the BGC module
+
+When compiling with the BGC module, ensure `ntracr` in `blkdat.input` is non-zero and
+copy the FABM configuration files and CICE namelist into the experiment directory before
+compiling HYCOM-CICE:
+
+```bash
+CONFIGNAME=<CONFIGNAME>   # e.g. TP2a0.10
+EXPT_ID=<EXPT_ID>         # e.g. 01.0
+
+cd ${WORK}/${CONFIGNAME}/expt_${EXPT_ID}
+cp /nird/datalake/NS9481K/shuang/TP2_setup/exp02.6_seaclim_ref/fabm.yaml .
+cp /nird/datalake/NS9481K/shuang/TP2_setup/exp02.6_seaclim_ref/hycom_fabm.nml .
+cp /nird/datalake/NS9481K/shuang/TP2_setup/exp02.6_seaclim_ref/ice_in .
+```
+
+These files are also required when running the model with BGC. Copy them to your scratch filesystem before starting a simulation with BGC.
+
+```bash
+CONFIGNAME=<CONFIGNAME>   # e.g. TP2a0.10
+EXPT_ID=<EXPT_ID>         # e.g. 01.0
+
+cp $WORK/${CONFIGNAME}/expt_${EXPT_ID}/fabm.yaml $WDIR/expt_${EXPT_ID}/.
+cp $WORK/${CONFIGNAME}/expt_${EXPT_ID}/hycom_fabm.nml $WDIR/expt_${EXPT_ID}/.
+cp $WORK/${CONFIGNAME}/expt_${EXPT_ID}/ice_in $WDIR/expt_${EXPT_ID}/.
+```
+
 ## Files in the experiment directory
 
 To conclude the experiment setup, here is an overview of everything now present in the

--- a/docs/forcing.md
+++ b/docs/forcing.md
@@ -340,12 +340,14 @@ Use `stage_nesting_files.sh` to copy or extract the files needed for a given dat
 ```bash
 CONFIGNAME=<CONFIGNAME>   # e.g. TP2a0.10
 IEXPT=<IEXPT>             # e.g. 010
+START=<START>             # e.g. 1993-01-01T00:00:00
+END=<END>                 # e.g. 2025-01-01T00:00:00
 
 $HOME/NERSC-HYCOM-CICE/bin/stage_nesting_files.sh \
     /nird/datalake/NS9481K/shuang/nest/TP2_expt023 \
     $WORK/${CONFIGNAME}/nest/${IEXPT} \
-    <START> \
-    <END>
+    ${START} \
+    ${END}
 ```
 Here, `START` and `END` are the run start and end times, see the [srjob.sh variable table](running.md#submit-a-job) for the
 expected format. Two optional flags are supported (in any order):

--- a/docs/forcing.md
+++ b/docs/forcing.md
@@ -716,12 +716,12 @@ cd $WORK/${CONFIGNAME}/expt_${EXPT_ID}
 mkdir -p ../nest/${IEXPT}/Montg
 python $HOME/NERSC-HYCOM-CICE/bin/calc_montg1.py \
     ../nest/${IEXPT}/archv.YYYY_DDD_00.a \
-    ./data/restart.YYYY_DDD_00_0000.a \
+    $USERWORK/${CONFIGNAME}/expt_${EXPT_ID}/data/restart.YYYY_DD_00_0000.a \
     ../nest/${IEXPT}/Montg/
 mv ../nest/${IEXPT}/Montg/archv.YYYY_DDD_00.[ab] ../nest/${IEXPT}/
 ```
 
-Replace `restart.YYYY_DDD_00_0000.a` with the actual restart file in `data/` (see
+Replace `restart.YYYY_DDD_00_0000.a` with the actual restart file in `$USERWORK/${CONFIGNAME}/expt_${EXPT_ID}/data/` (see
 [Restart files](#restart-files)), and `archv.YYYY_DDD_00.a` with the nesting file whose Montgomery potential you want to modify.
 
 :::{dropdown} What calc_montg1.py does
@@ -794,7 +794,7 @@ Once inside the session, activate the Python environment:
 CONFIGNAME=<CONFIGNAME>   # e.g. TP2a0.10
 IEXPT=<IEXPT>             # e.g. 010
 EXPT_ID=<EXPT_ID>         # e.g. 01.0
-restartfile="./data/restart.YYYY_DDD_00_0000.a"  # adapt to your restart file
+restartfile=$USERWORK/${CONFIGNAME}/expt_${EXPT_ID}/data/restart.YYYY_DDD_00_0000.a"  # adapt to your restart file
 
 cd $WORK/${CONFIGNAME}/expt_${EXPT_ID}
 outdir="../nest/${IEXPT}/Montg"
@@ -860,7 +860,7 @@ conda activate hycom-cice
 CONFIGNAME=<CONFIGNAME>   # e.g. TP2a0.10
 IEXPT=<IEXPT>             # e.g. 010
 EXPT_ID=<EXPT_ID>         # e.g. 01.0
-restartfile="./data/restart.YYYY_DDD_00_0000.a"  # adapt to your restart file
+restartfile=$USERWORK/${CONFIGNAME}/expt_${EXPT_ID}/data/restart.YYYY_DDD_00_0000.a  # adapt to your restart file
 
 outdir="../nest/${IEXPT}/Montg"
 mkdir -p ${outdir}

--- a/docs/forcing.md
+++ b/docs/forcing.md
@@ -340,14 +340,12 @@ Use `stage_nesting_files.sh` to copy or extract the files needed for a given dat
 ```bash
 CONFIGNAME=<CONFIGNAME>   # e.g. TP2a0.10
 IEXPT=<IEXPT>             # e.g. 010
-START=<START>             # e.g. 1993-01-01T00:00:00
-END=<END>                 # e.g. 2025-01-01T00:00:00
 
 $HOME/NERSC-HYCOM-CICE/bin/stage_nesting_files.sh \
     /nird/datalake/NS9481K/shuang/nest/TP2_expt023 \
     $WORK/${CONFIGNAME}/nest/${IEXPT} \
-    ${START} \
-    ${END}
+    <START> \
+    <END>
 ```
 Here, `START` and `END` are the run start and end times, see the [srjob.sh variable table](running.md#submit-a-job) for the
 expected format. Two optional flags are supported (in any order):

--- a/docs/running.md
+++ b/docs/running.md
@@ -72,6 +72,9 @@ For reference when setting `#SBATCH --time`: a 1-year TP2 run with BGC on 4 Betz
 Then submit:
 
 ```bash
+CONFIGNAME=<CONFIGNAME>   # e.g. TP2a0.10
+EXPT_ID=<EXPT_ID>         # e.g. 01.0
+
 cd $WORK/<CONFIGNAME>/expt_<EXPT_ID>
 sbatch srjob.sh
 ```
@@ -92,6 +95,9 @@ When the job finishes, restart files and daily mean files are moved to the `data
 Confirm successful completion by checking the stop file:
 
 ```bash
+CONFIGNAME=<CONFIGNAME>   # e.g. TP2a0.10
+EXPT_ID=<EXPT_ID>         # e.g. 01.0
+
 cat $WORK/<CONFIGNAME>/expt_<EXPT_ID>/log/hycom.stop
 ```
 
@@ -113,6 +119,9 @@ What happens to output files depends on how the run ended:
   Run postprocessing manually before resubmitting:
 
   ```bash
+  CONFIGNAME=<CONFIGNAME>   # e.g. TP2a0.10
+  EXPT_ID=<EXPT_ID>         # e.g. 01.0
+
   cd $WORK/<CONFIGNAME>/expt_<EXPT_ID>
   ../expt_postprocess.sh
   ```


### PR DESCRIPTION
## Description

This PR changes the documentation to
* clarify how to set SCRATCH and data directories on Betzy and Olivia. These pieces of information were there before, but were buried in a dropdown without explicit mentioning in the "main text";
* instruct the user to copy their `hycom.opt` from their WORK to their SCRATCH system (this step was previously missing)
* add a list at the end of the "Experiment setup" page with all the files that are now present in the experiment directory.

## Checklist

- [x] I have updated the documentation to reflect these changes, where relevant.

  See the [contributor guide](https://nersc-hycom-cice.readthedocs.io/en/latest/contributing.html#previewing-documentation-changes-in-a-pr) for how to preview your documentation changes.

- [x] I have tested these changes, where relevant.
